### PR TITLE
♻️  eslint-config-next 🚨️ update linting throughout repo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ const config = require('@jeromefitz/codestyle/.eslintrc.js')
 
 module.exports = {
   ...config,
+  extends: [...config.extends, 'next'],
   rules: {
     ...config.rules,
     'import/order': 0, // @todo

--- a/components/Dynamic/dynamic.tsx
+++ b/components/Dynamic/dynamic.tsx
@@ -92,7 +92,7 @@ const LI = ({ children, ...props }) => {
   )
 }
 
-export default {
+const dynamicElements = {
   // default tags
   b: 'strong',
   i: 'em',
@@ -122,3 +122,5 @@ export default {
   Column: dynamic(() => import('./column')),
   // Counter: dynamic(() => import('./counter')),
 }
+
+export default dynamicElements

--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -6,7 +6,7 @@ import { FaPencilRuler } from 'react-icons/fa'
 
 import NowPlaying from '~components/NowPlaying'
 
-const Footer = memo(() => {
+const Footer = () => {
   const [mounted, setMounted] = useState(false)
   useEffect(() => setMounted(true), [])
   return (
@@ -61,6 +61,6 @@ const Footer = memo(() => {
       )}
     </>
   )
-})
+}
 
-export default Footer
+export default memo(Footer)

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -15,6 +15,7 @@ const Loading = () => (
 )
 
 const dynamicProps = {
+  // eslint-disable-next-line react/display-name
   loading: () => <Loading />,
 }
 

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -12,7 +12,7 @@ import { IoMdMoon } from 'react-icons/io'
 import SplitText from '~components/SplitText'
 import { navigation as links } from '~config/notion/website'
 
-const Navigation = memo(() => {
+const Navigation = () => {
   const { theme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
   useEffect(() => setMounted(true), [])
@@ -109,6 +109,6 @@ const Navigation = memo(() => {
       <SkipNavContent />
     </>
   )
-})
+}
 
-export default Navigation
+export default memo(Navigation)

--- a/components/NowPlaying/NowPlayingWithControls.tsx
+++ b/components/NowPlaying/NowPlayingWithControls.tsx
@@ -132,6 +132,7 @@ const NowPlaying = () => {
                   title={data?.album}
                   width={450}
                 /> */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   alt={`Album Cover for ${data?.album}`}
                   // height={450}

--- a/config/notion/schema/routeTypes/index.ts
+++ b/config/notion/schema/routeTypes/index.ts
@@ -11,7 +11,7 @@ import venues from './venues'
 
 export { blog, episodes, events, pages, people, podcasts, seo, shows, users, venues }
 
-export default {
+const routeTypes = {
   blog,
   episodes,
   events,
@@ -23,3 +23,5 @@ export default {
   users,
   venues,
 }
+
+export default routeTypes

--- a/lib/focusTrap.ts
+++ b/lib/focusTrap.ts
@@ -56,6 +56,7 @@ export default function FocusTrap({ children, focusFirst = false }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [root, children])
 
+  // eslint-disable-next-line react/no-children-prop
   return React.createElement('div', {
     ref: root,
     children,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "analyze": "BUNDLE_ANALYZE=both yarn build",
     "build": "next build",
+    "branch": "git-cz -m branch --allow-empty",
     "clean": "./scripts/clean.sh",
     "clean:install": "yarn run clean && yarn install",
     "dev": "next dev",

--- a/pages/api/images/index.ts
+++ b/pages/api/images/index.ts
@@ -1,10 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { getPlaiceholder } from 'plaiceholder'
 
-export default async (_req: NextApiRequest, res: NextApiResponse) => {
+const imagesApi = async (_req: NextApiRequest, res: NextApiResponse) => {
   const { base64, img } = await getPlaiceholder(
     'https://cdn.jeromefitzgerald.com/jeromefitzgerald.com/images/2020/01/_original/2020-01--sf-sketchfest--000--jerome--bob-shields.jpg'
   )
 
   return res.status(200).json({ base64, img })
 }
+
+export default imagesApi

--- a/pages/api/rss/[...catchAll].ts
+++ b/pages/api/rss/[...catchAll].ts
@@ -22,7 +22,7 @@ const url = getNextSeo.custom.url
 
 const isTrue = (val) => (val === 'Yes' ? true : false)
 
-export default async (req: NextApiRequest, res: NextApiResponse) => {
+const rssApi = async (req: NextApiRequest, res: NextApiResponse) => {
   let feed: any = null
 
   isDebug && console.dir(`api/rss/[...catchAll]].js`)
@@ -246,3 +246,5 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   }
   return true
 }
+
+export default rssApi

--- a/pages/api/spotify/[slug].ts
+++ b/pages/api/spotify/[slug].ts
@@ -3,7 +3,7 @@ import { getNowPlaying, getTopArtists, getTopTracks } from '~lib/spotify'
 // @todo(routes) Lock this down a bit beter with Typescript
 // const allowedRoutes = ['now-playing', 'top-artists', 'top-tracks']
 
-export default async ({ query: { limit, slug, time_range } }, res) => {
+const spotifyApi = async ({ query: { limit, slug, time_range } }, res) => {
   switch (slug) {
     case 'now-playing':
       const response = await getNowPlaying()
@@ -102,3 +102,5 @@ export default async ({ query: { limit, slug, time_range } }, res) => {
       break
   }
 }
+
+export default spotifyApi

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ import Seo from '~components/Seo'
 import { sites } from '../next.sitemap'
 const { description, title } = sites[process.env.NEXT_PUBLIC__SITE]
 
-import routeTypes from '~config/notion/website'
+import { routeTypes } from '~config/notion/website'
 const routeType = 'pages'
 const slug = 'homepage'
 

--- a/zzz/api/github/index.ts
+++ b/zzz/api/github/index.ts
@@ -1,4 +1,4 @@
-export default async (_, res) => {
+const githubApi = async (_, res) => {
   const userResponse = await fetch('https://api.github.com/users/JeromeFitz')
   const userReposResponse = await fetch(
     'https://api.github.com/users/JeromeFitz/repos'
@@ -20,3 +20,5 @@ export default async (_, res) => {
     stars,
   })
 }
+
+export default githubApi

--- a/zzz/api/notion/zzz-old.ts
+++ b/zzz/api/notion/zzz-old.ts
@@ -31,7 +31,7 @@ const nonPreviewTypes = new Set(['editor', 'page', 'collection_view'])
 //   })
 // )
 
-export default async (req: NextApiRequest, res: NextApiResponse) => {
+const notionApi = async (req: NextApiRequest, res: NextApiResponse) => {
   // await cors(req, res)
 
   isDebug && console.dir(`api/notion/[...catchAll]].js`)
@@ -527,3 +527,5 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
   return true
 }
+
+export default notionApi

--- a/zzz/api/views/[slug].ts
+++ b/zzz/api/views/[slug].ts
@@ -1,6 +1,6 @@
 import db from '~lib/firebase'
 
-export default async (req, res) => {
+const viewsSlugApi = async (req, res) => {
   if (req.method === 'POST') {
     const ref = db.ref('views').child(req.query.slug)
     const { snapshot } = await ref.transaction((currentViews: number) => {
@@ -22,3 +22,5 @@ export default async (req, res) => {
     return res.status(200).json({ total: views })
   }
 }
+
+export default viewsSlugApi

--- a/zzz/api/views/index.ts
+++ b/zzz/api/views/index.ts
@@ -1,6 +1,6 @@
 import db from '~lib/firebase'
 
-export default async (_, res) => {
+const viewsApi = async (_, res) => {
   const snapshot = await db.ref('views').once('value')
   const views = snapshot.val()
   const allViews = Object.values(views).reduce(
@@ -9,3 +9,5 @@ export default async (_, res) => {
 
   return res.status(200).json({ total: allViews })
 }
+
+export default viewsApi


### PR DESCRIPTION
# eslint-config-next

This refactors to truly use `eslint-config-next` and the code updates required to be compliant.
This updates the `.eslintrc` ahead of any changes to `@jeromefitz/codestyle` as we'll need a new `eslint.nextjs` file I guess.