### PR TITLE
🚑️  outputFileTracing: false

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -123,6 +123,7 @@ const nextConfig = {
     locales: ['en'],
     defaultLocale: 'en',
   },
+  outputFileTracing: false,
   pageExtensions: ['jsx', 'js', 'tsx', 'ts'],
   poweredByHeader: false,
   // reactStrictMode: true,


### PR DESCRIPTION
Reference: https://github.com/vercel/next.js/issues/30561#issuecomment-954032510

This is happening for non-generated at run-time fallbacks:
- `/events/2020` for example:

```bash
[GET] /events/2020
15:29:05:35
2021-10-28T19:29:05.416Z	fa7e0674-ff50-4f22-9453-a757c65fbde3	ERROR	Error: Cannot find module '/var/task/node_modules/swr/dist/index.js'
    at createEsmNotFoundErr (internal/modules/cjs/loader.js:916:15)
    at finalizeEsmResolution (internal/modules/cjs/loader.js:909:15)
    at resolveExports (internal/modules/cjs/loader.js:449:14)
    at Function.Module._findPath (internal/modules/cjs/loader.js:489:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:875:27)
    at Function.Module._load (internal/modules/cjs/loader.js:745:27)
    at Module.require (internal/modules/cjs/loader.js:961:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at Object.549 (/var/task/.next/server/pages/_app.js:462:18)
    at __webpack_require__ (/var/task/.next/server/webpack-runtime.js:25:42) {
  code: 'MODULE_NOT_FOUND',
  path: '/var/task/node_modules/swr/package.json'
}
```