### PR TITLE
♻️  `ImageBlur` for `ImageLead` do not use blocking `url()`

### DIFF
--- a/sites/jeromefitzgerald.com/src/components/Layout/ImageLead.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Layout/ImageLead.tsx
@@ -7,8 +7,8 @@ import {
 } from '@jeromefitz/design-system/components'
 import { darkTheme } from '@jeromefitz/design-system/stitches.config'
 import _isEmpty from 'lodash/isEmpty'
-import * as React from 'react'
-import { useIsomorphicLayoutEffect } from 'react-use'
+// import * as React from 'react'
+// import { useIsomorphicLayoutEffect } from 'react-use'
 import useSWR from 'swr'
 
 import fetcher from '~lib/fetcher'
@@ -34,34 +34,31 @@ const ImageWithBackgroundBlur = ({
 }) => {
   const { height, src, width } = image
 
-  const [backgroundImageLoaded, backgroundImageLoadedSet] = React.useState(false)
-
-  useIsomorphicLayoutEffect(() => {
-    backgroundImageLoadedSet(true)
-    return () => {
-      backgroundImageLoadedSet(false)
-    }
-  })
+  // const [backgroundImageLoaded, backgroundImageLoadedSet] = React.useState(false)
+  // useIsomorphicLayoutEffect(() => {
+  //   backgroundImageLoadedSet(true)
+  //   return () => {
+  //     backgroundImageLoadedSet(false)
+  //   }
+  // })
 
   return (
     <ImageContainer>
       <ImageBlur
         css={{
           // backgroundImage: `url(${base64})`,
-          backgroundImage: backgroundImageLoaded
-            ? `url(${base64}),linear-gradient(45deg,$colors$blackA7,$colors$blackA12)`
-            : `linear-gradient(45deg,$colors$blackA7,$colors$blackA12)`,
-          // backgroundImage: `linear-gradient(45deg,$colors$blackA7,$colors$blackA12)`,
-          // backgroundImage: `url(${base64}),linear-gradient(40deg,#fff,#000)`,
+          // backgroundImage: backgroundImageLoaded
+          //   ? `url(${base64}),linear-gradient(45deg,$colors$blackA7,$colors$blackA12)`
+          //   : `linear-gradient(45deg,$colors$blackA7,$colors$blackA12)`,
+          backgroundImage: `linear-gradient(45deg,$colors$blackA7,$colors$blackA12)`,
           backgroundSize: 'cover',
           borderRadius: '$4',
           [`.${darkTheme} &`]: {
             // backgroundImage: `url(${base64})`,
-            backgroundImage: backgroundImageLoaded
-              ? `url(${base64}),linear-gradient(45deg,$colors$whiteA7,$colors$whiteA12)`
-              : `linear-gradient(45deg,$colors$whiteA7,$colors$whiteA12)`,
-            // backgroundImage: `linear-gradient(45deg,$colors$whiteA7,$colors$whiteA12)`,
-            // backgroundImage: `url(${base64}),linear-gradient(40deg,#000,#fff)`,
+            // backgroundImage: backgroundImageLoaded
+            // ? `url(${base64}),linear-gradient(45deg,$colors$whiteA7,$colors$whiteA12)`
+            // : `linear-gradient(45deg,$colors$whiteA7,$colors$whiteA12)`,
+            backgroundImage: `linear-gradient(45deg,$colors$whiteA7,$colors$whiteA12)`,
           },
         }}
       />

--- a/sites/jeromefitzgerald.com/src/lib/notion/app/components/image.tsx
+++ b/sites/jeromefitzgerald.com/src/lib/notion/app/components/image.tsx
@@ -84,12 +84,12 @@ const image = ({ images, item }) => {
           backgroundRepeat: 'no-repeat',
           backgroundSize: '100%',
           // backgroundImage: `url(${IMAGE__PLACEHOLDER.meta.base64})`,
-          backgroundImage: `linear-gradient(40deg,#fff,#000)`,
-          // backgroundImage: `url(${IMAGE__PLACEHOLDER.meta.base64}),linear-gradient(40deg,#fff,#000)`,
+          backgroundImage: `linear-gradient(45deg,$colors$blackA7,$colors$blackA12)`,
+          // backgroundImage: `url(${IMAGE__PLACEHOLDER.meta.base64}),linear-gradient(45deg,$colors$blackA7,$colors$blackA12)`,
           [`.${darkTheme} &`]: {
             // backgroundImage: `url(${IMAGE__PLACEHOLDER.meta.base64})`,
-            backgroundImage: `linear-gradient(40deg,#000,#fff)`,
-            // backgroundImage: `url(${IMAGE__PLACEHOLDER.meta.base64}),linear-gradient(40deg,#000,#fff)`,
+            backgroundImage: `linear-gradient(45deg,$colors$whiteA7,$colors$whiteA12)`,
+            // backgroundImage: `url(${IMAGE__PLACEHOLDER.meta.base64}),linear-gradient(45deg,$colors$whiteA7,$colors$whiteA12)`,
           },
         }}
       />


### PR DESCRIPTION
- ♻️ `ImageBlur` for `ImageLead` do not use blocking `url()`

Though admittedly this is pretty cool to show the Image's color pattern on the Blur/Glow that happens around it.

For `ImageLead` this is bad practice (especially) as the load _needs_ the `url()` to generate.


Things to test / verify before merge:
- [x] LCP/FCP improvement w/o `url()`
  - By improvement LCP and TBT consistently green
  - Right now it wavers between yellow and red
- [x] Any improvement w/ fallback `linear-gradient` accompanying `url()`?
  - Here for the design aesthetic, if we could get consistency in always knowing it is going to be `yellow` instead of venturing into `red` then that may be acceptable. It's the randomness at the moment that would like to be defined.


## Update

Whoa, okay. Yea, I do not think the design aesthetic is worth it. Perhaps we could swap it post render (or transition).

The consistency in Gradient Only is 💯 

Gradient Only:
- URL: `https://jeromefitzgerald-7fjz6w7j0-jerome5.vercel.app/`
- TBT: `80ms`, `230ms`, `120ms`
- LCP: `0.4s`, `0.7s`, `0.5s`
- Speed Index: `0.6s`, `0.6s`, `0.7s`

Gradient + Image:
- URL: `https://jeromefitzgerald-b39qcp2h3-jerome5.vercel.app/`
- TBT: `570ms`, `250ms`, `130ms`
- LCP: `0.4s`, `0.4s`, `0.6s`
- Speed Index: `1.2s`, `0.7.s`, `0.8s`

This is really good, but we are going to go w/ the consistency on the `TBT` with gradient only.

Image Only:
- URL: `https://jeromefitzgerald.com`
- TBT: `940ms`,  `190ms`, `800ms`
- LCP: `0.8s`, `0.4s`, `0.5s`
- Speed Index: `1.6s`, `0.6s`, `0.9s`

#### Since we are here

Any improvement only loading `url()` after render? May need to move this to `useIsomorphicLayoutEffect`:
- URL: `https://jeromefitzgerald-c0fgrlijz-jerome5.vercel.app/`
- TBT: `160ms`,  `280ms`, `90ms`
- LCP: `0.4s`, `0.5s`, `0.4s`
- Speed Index: `0.7.s`, `0.6s`, `0.5s`

Hrm ... best of both worlds potentially? 🤔 

I think if we move this to `useLayoutEfect` via `useIsomorphicLayoutEffect` it will be. Still a bit of a flicker.



Before merge:
- [x] Verify gradient with `darkTheme` and color scheme 