### PR TITLE
👷  (actions) `_init-and-lint.yml`, reduce to emoji labels

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -1,4 +1,4 @@
-name: '🚀️  Deploy'
+name: '🚀️  '
 
 on:
   workflow_call:
@@ -18,7 +18,7 @@ on:
 
 jobs:
   deploy:
-    name: '👷️  Deploy'
+    name: '🔺️  '
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/_init-and-lint.yml
+++ b/.github/workflows/_init-and-lint.yml
@@ -1,4 +1,4 @@
-name: '👷️  CI'
+name: '👷️  '
 
 on:
   workflow_call:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint:
-    name: '👷️  I+L'
+    name: '💽️  +  🚨️  '
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,4 +1,4 @@
-name: '▶️ Pull'
+name: '▶️ '
 
 on:
   pull_request:
@@ -29,18 +29,18 @@ env:
 
 jobs:
   call-init-and-lint:
-    name: '👷️  CI'
+    name: '👷️  '
     if: github.event.pull_request.draft == false && !contains(github.event.head_commit.message, '[skip ci]')
-    uses: JeromeFitz/jeromefitzgerald.com/.github/workflows/_init-and-lint.yml@ci/actions-vs-workflows
+    uses: JeromeFitz/jeromefitzgerald.com/.github/workflows/_init-and-lint.yml@main
     secrets:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
   call-deploy:
-    name: '🚀️  Deploy (Preview)'
+    name: '🚀️  (Preview)'
     if: github.event.pull_request.draft == false && !contains(github.event.head_commit.message, '[skip ci]')
     needs: call-init-and-lint
-    uses: JeromeFitz/jeromefitzgerald.com/.github/workflows/_deploy.yml@ci/actions-vs-workflows
+    uses: JeromeFitz/jeromefitzgerald.com/.github/workflows/_deploy.yml@main
     with:
       PRODUCTION: false
     secrets:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: '🔀️ Push'
+name: '🔀️ '
 
 on:
   push:
@@ -28,26 +28,26 @@ env:
 
 jobs:
   call-init-and-lint:
-    name: '👷️  CI'
+    name: '👷️  '
     if: (contains(github.event.head_commit.message, '[build]') || contains(github.event.head_commit.message, '[b]') || github.ref == 'refs/heads/main') && !contains(github.event.head_commit.message, '[skip ci]')
-    uses: JeromeFitz/jeromefitzgerald.com/.github/workflows/_init-and-lint.yml@ci/actions-vs-workflows
+    uses: JeromeFitz/jeromefitzgerald.com/.github/workflows/_init-and-lint.yml@main
     secrets:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
   call-release:
-    name: '🏷️  Release'
+    name: '🏷️  '
     if: (contains(github.event.head_commit.message, '[build]') || contains(github.event.head_commit.message, '[b]') || github.ref == 'refs/heads/main') && !contains(github.event.head_commit.message, '[skip ci]')
     needs: call-init-and-lint
-    uses: JeromeFitz/jeromefitzgerald.com/.github/workflows/_release.yml@ci/actions-vs-workflows
+    uses: JeromeFitz/jeromefitzgerald.com/.github/workflows/_release.yml@main
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
   call-deploy:
-    name: '🚀️  Deploy (Production)'
+    name: '🚀️  (Production)'
     if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip ci]')
     needs: call-release
-    uses: JeromeFitz/jeromefitzgerald.com/.github/workflows/_deploy.yml@ci/actions-vs-workflows
+    uses: JeromeFitz/jeromefitzgerald.com/.github/workflows/_deploy.yml@main
     with:
       PRODUCTION: true
     secrets:


### PR DESCRIPTION
Wasting time `init` to use the cache in `lint` here. Keep both for now, but only call `_init-and-lint`

For Vercel, it's as fast as it'll go for now.

The way to improve this further would be to not concern ourselves with getting the success back from Vercel, and instead either skip that wait, or find a way to eject the wait.

The value in us doing this here again is that we do not want to do `lint/ test` on Vercel, but we also do not wan to create a deployment if there is an obvious problem.