### PR TITLE
💚  (actions) 🍽️  of `deploy-to-vercel-action` test

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: '🔺️ Deploy'
       id: wf-deploy
-      uses: jeromefitz/deploy-to-vercel-action@ci/vercel-deploy-commit-limits
+      uses: JeromeFitz/deploy-to-vercel-action@ci/vercel-deploy-commit-limits
       with:
         GITHUB_TOKEN: ${{ inputs.GH_TOKEN }}
         VERCEL_ORG_ID: ${{ inputs.VERCEL_ORG_ID }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: '🔺️ Deploy'
       id: wf-deploy
-      uses: BetaHuhn/deploy-to-vercel-action@v1
+      uses: jeromefitz/deploy-to-vercel-action@ci/vercel-deploy-commit-limits
       with:
         GITHUB_TOKEN: ${{ inputs.GH_TOKEN }}
         VERCEL_ORG_ID: ${{ inputs.VERCEL_ORG_ID }}


### PR DESCRIPTION
Previously if the `commit.message` of the `SHA` was very long:

- `pull_request`: with a lot of information the commit message (dependabot, feature, etc.)

This was creating a very large `githubCommitMessage` environment variable which was breaking (specifically) production builds from `main`:

```sh
Error! The total size of all Environment Variables (9.1KB) exceeds 4KB.
[51](https://github.com/JeromeFitz/websites/runs/5115282111?check_suite_focus=true#step:6:51)
Learn More: https://vercel.link/env-vars-limit
```

Being that there are less than 10 environment variables for this website, the hope is this was the culprit.

I am also adding a lot of information in this PR to ensure we are well over the `50` character limit which is now imposed by it truncating in the forked repo.

If this works (when? wishful thinking) then we'll create a PR to see if it may be helpful at all.