### PR TITLE
🐛  banner next event; ⛳ banner flag

### DIFF
--- a/sites/jeromefitzgerald.com/next.config.js
+++ b/sites/jeromefitzgerald.com/next.config.js
@@ -58,6 +58,7 @@ const isLocalDebugMessages = [
  */
 const envRequired = [
   'GH_TOKEN',
+  'NEXT_PUBLIC__EVENT_UPCOMING_FLAG',
   'NEXT_PUBLIC__FATHOM_CUSTOM_DOMAIN',
   'NEXT_PUBLIC__FATHOM_SITE_ID',
   'NEXT_PUBLIC__SITE',

--- a/sites/jeromefitzgerald.com/src/components/Banner/Banner.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Banner/Banner.tsx
@@ -15,6 +15,7 @@ import { Shadows } from '@jeromefitz/shared/src/styles/const'
 // import { Gradients, Shadows } from '@jeromefitz/shared/src/styles/const'
 import { parseISO } from 'date-fns'
 import { formatInTimeZone as _formatInTimeZone } from 'date-fns-tz'
+import _orderBy from 'lodash/orderBy'
 import { fetcher } from 'next-notion/src/lib/fetcher'
 import { getNextPageStatus } from 'next-notion/src/utils'
 import NextLink from 'next/link'
@@ -77,7 +78,9 @@ const BannerImpl = () => {
   )
 
   const isLoaded = !is404 && !isLoading && !isError && !isDataUndefined
-  const item = data?.items?.results[0]
+  const items = data?.items?.results
+  const itemsSorted = _orderBy(items, ['properties.dateEvent.start'], ['asc'])
+  const item = itemsSorted[0]
   const hasItem = isLoaded && !!item
   // if (!hasItem) return null
 

--- a/sites/jeromefitzgerald.com/src/components/Header/Header.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Header/Header.tsx
@@ -1,10 +1,12 @@
 import { AppBar } from '../AppBar'
-// import { Banner } from '../Banner'
+import { Banner } from '../Banner'
 
 const Header = () => {
+  const isEventUpcoming =
+    process.env.NEXT_PUBLIC__EVENT_UPCOMING_FLAG === 'true' ? true : false
   return (
     <>
-      {/* <Banner /> */}
+      {isEventUpcoming && <Banner />}
       <AppBar />
     </>
   )


### PR DESCRIPTION
- Displays `Banner` if the Environment Variable is set (`NEXT_PUBLIC__EVENT_UPCOMING_FLAG`)
  - 💩 do not want to show `Banner` if no Events (constant loading)
  - 💡 ideally would have a fall-back blog post or behavior and remove this
- When showing an Event in the Banner should show the _next_ event
  - 💡 maybe down the line this is a slide show of all upcoming