### PR TITLE
✨  (poc) NICE-57 next => draft + revalidate [b]

### DIFF
--- a/sites/jeromefitzgerald.com/src/app/(notion)/(config)/utils/getPageDataFromNotion.ts
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/(config)/utils/getPageDataFromNotion.ts
@@ -7,7 +7,7 @@ import { getCache, setCache, getKey } from '~app/(cache)'
 const OVERRIDE_CACHE = process.env.OVERRIDE_CACHE || false
 
 /**
- * @todo(next) revalidate | preview
+ * @todo(next) draft | revalidate
  */
 const getPageDataFromNotion = cache(async (id) => {
   let data

--- a/sites/jeromefitzgerald.com/src/app/(notion)/about/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/about/page.tsx
@@ -3,6 +3,7 @@
  */
 import { isObjectEmpty } from '@jeromefitz/utils'
 // import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
+import { draftMode } from 'next/headers'
 
 import { getDataFromCache } from '~app/(cache)'
 import { CONSTANTS } from '~app/(notion)/(config)/constants'
@@ -22,12 +23,13 @@ import { Testing } from '~components/Testing'
 
 const { SEGMENT } = CONSTANTS.PAGES
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   // console.dir(segmentInfo)
   // const data: QueryDatabaseResponse = await getDatabaseQuery({
   //   database_id: DATABASE_ID,
+  //   draft: isEnabled,
   //   filterType: 'starts_with',
-  //   preview,
   //   revalidate,
   //   segmentInfo: {
   //     ...segmentInfo,
@@ -36,8 +38,8 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   // })
   const data = await getDataFromCache({
     database_id: '',
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo: {
       ...segmentInfo,
@@ -71,11 +73,11 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   )
 }
 
-export default function Page({ preview = false, revalidate = false, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   // if (segmentInfo.isIndex) {
-  //   return <Listing preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  //   return <Listing revalidate={revalidate} segmentInfo={segmentInfo} />
   // }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }

--- a/sites/jeromefitzgerald.com/src/app/(notion)/books/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/books/page.tsx
@@ -3,6 +3,7 @@
  */
 import { isObjectEmpty } from '@jeromefitz/utils'
 // import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
+import { draftMode } from 'next/headers'
 
 import { getDataFromCache } from '~app/(cache)'
 import { CONSTANTS } from '~app/(notion)/(config)/constants'
@@ -21,12 +22,13 @@ import { Testing } from '~components/Testing'
 
 const { SEGMENT } = CONSTANTS.PAGES
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   // console.dir(segmentInfo)
   // const data: QueryDatabaseResponse = await getDatabaseQuery({
   //   database_id: DATABASE_ID,
+  //   draft: isEnabled,
   //   filterType: 'starts_with',
-  //   preview,
   //   revalidate,
   //   segmentInfo: {
   //     ...segmentInfo,
@@ -35,8 +37,8 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   // })
   const data = await getDataFromCache({
     database_id: '',
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo: {
       ...segmentInfo,
@@ -71,11 +73,11 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   )
 }
 
-export default function Page({ preview = false, revalidate = true, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   // if (segmentInfo.isIndex) {
-  //   return <Listing segmentInfo={segmentInfo} />
+  //   return <Listing srevalidate={revalidate} egmentInfo={segmentInfo} />
   // }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }

--- a/sites/jeromefitzgerald.com/src/app/(notion)/colophon/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/colophon/page.tsx
@@ -3,6 +3,7 @@
  */
 import { isObjectEmpty } from '@jeromefitz/utils'
 // import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
+import { draftMode } from 'next/headers'
 
 import { getDataFromCache } from '~app/(cache)'
 import { CONSTANTS } from '~app/(notion)/(config)/constants'
@@ -22,12 +23,13 @@ import { Testing } from '~components/Testing'
 
 const { SEGMENT } = CONSTANTS.PAGES
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   // console.dir(segmentInfo)
   // const data: QueryDatabaseResponse = await getDatabaseQuery({
   //   database_id: DATABASE_ID,
+  //   draft: isEnabled,
   //   filterType: 'starts_with',
-  //   preview,
   //   revalidate,
   //   segmentInfo: {
   //     ...segmentInfo,
@@ -36,8 +38,8 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   // })
   const data = await getDataFromCache({
     database_id: '',
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo: {
       ...segmentInfo,
@@ -71,11 +73,11 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   )
 }
 
-export default function Page({ preview = false, revalidate = false, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   // if (segmentInfo.isIndex) {
-  //   return <Listing preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  //   return <Listing revalidate={revalidate} segmentInfo={segmentInfo} />
   // }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }

--- a/sites/jeromefitzgerald.com/src/app/(notion)/contact/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/contact/page.tsx
@@ -3,6 +3,7 @@
  */
 import { isObjectEmpty } from '@jeromefitz/utils'
 // import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
+import { draftMode } from 'next/headers'
 
 import { getDataFromCache } from '~app/(cache)'
 import { CONSTANTS } from '~app/(notion)/(config)/constants'
@@ -21,12 +22,13 @@ import { Testing } from '~components/Testing'
 
 const { SEGMENT } = CONSTANTS.PAGES
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   // console.dir(segmentInfo)
   // const data: QueryDatabaseResponse = await getDatabaseQuery({
   //   database_id: DATABASE_ID,
+  //   draft: isEnabled,
   //   filterType: 'starts_with',
-  //   preview,
   //   revalidate,
   //   segmentInfo: {
   //     ...segmentInfo,
@@ -35,8 +37,8 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   // })
   const data = await getDataFromCache({
     database_id: '',
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo: {
       ...segmentInfo,
@@ -71,11 +73,11 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   )
 }
 
-export default function Page({ preview = false, revalidate = false, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   // if (segmentInfo.isIndex) {
-  //   return <Listing preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  //   return <Listing revalidate={revalidate} segmentInfo={segmentInfo} />
   // }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }

--- a/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/Event.Slug.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/Event.Slug.tsx
@@ -15,6 +15,7 @@ import { isObjectEmpty } from '@jeromefitz/utils'
 // import { Client } from '@notionhq/client'
 import { Redis } from '@upstash/redis'
 import { slug as _slug } from 'github-slugger'
+import { draftMode } from 'next/headers'
 import NextImage from 'next/image'
 import { notFound } from 'next/navigation'
 import { isImageExpired } from 'next-notion/src/utils/getAwsImage'
@@ -268,12 +269,13 @@ function Ticket({ properties, isFakePortal = false }) {
   )
 }
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   // const { slug } = segmentInfo
   const data = await getDataFromCache({
     database_id: DATABASE_ID,
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo,
   })

--- a/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/page.tsx
@@ -1,6 +1,6 @@
 import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
-import isEqual from 'lodash/isEqual'
-import uniqWith from 'lodash/uniqWith'
+// import isEqual from 'lodash/isEqual'
+// import uniqWith from 'lodash/uniqWith'
 import type { Metadata } from 'next'
 
 import { getDataFromCache } from '~app/(cache)'
@@ -51,7 +51,9 @@ async function _generateStaticParams({ ...props }) {
   // })
   const dataStatic: QueryDatabaseResponse = await getDatabaseQuery({
     database_id: DATABASE_ID,
+    draft: false,
     filterType: 'starts_with',
+    revalidate: false,
     segmentInfo,
   })
   const hasContent = dataStatic?.results?.length > 0
@@ -76,11 +78,11 @@ async function _generateStaticParams({ ...props }) {
       /**
        * @todo(next) build/cache this gets kind of in-depth
        */
-      const isEvent = segmentInfo.segment === 'events' // && !segmentInfo.isIndex
-      if (isEvent) {
-        console.dir(`*** ${catchAll[0]}`)
-        if (catchAll[0] !== 2023) return null
-      }
+      // const isEvent = segmentInfo.segment === 'events' // && !segmentInfo.isIndex
+      // if (isEvent) {
+      //   console.dir(`*** ${catchAll[0]}`)
+      //   if (catchAll[0] !== 2023) return null
+      // }
 
       segments.push({ catchAll })
       if (catchAll.length > 0) {
@@ -92,25 +94,23 @@ async function _generateStaticParams({ ...props }) {
       return
     })
   }
-  const routes = !!combos && uniqWith(combos, isEqual)
-  !!routes && console.dir(`routes: turned off for now`)
-  !!routes && console.dir(routes)
+  // const routes = !!combos && uniqWith(combos, isEqual)
+  // !!routes && console.dir(`routes: turned off`)
+  // !!routes && console.dir(routes)
   // !!routes && routes.map((route) => segments.push(route))
 
-  console.dir(segments)
+  // console.dir(segments)
 
   return segments
 }
 const generateStaticParams = isDev ? undefined : _generateStaticParams
 export { generateStaticParams }
 
-export default function Page({ preview = false, revalidate = false, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   if (segmentInfo.isIndex) {
-    return (
-      <Listing preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
-    )
+    return <Listing revalidate={revalidate} segmentInfo={segmentInfo} />
   }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }

--- a/sites/jeromefitzgerald.com/src/app/(notion)/music/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/music/page.tsx
@@ -3,6 +3,7 @@
  */
 import { isObjectEmpty } from '@jeromefitz/utils'
 // import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
+import { draftMode } from 'next/headers'
 
 import { getDataFromCache } from '~app/(cache)'
 import { CONSTANTS } from '~app/(notion)/(config)/constants'
@@ -21,12 +22,13 @@ import { Testing } from '~components/Testing'
 
 const { SEGMENT } = CONSTANTS.PAGES
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   // console.dir(segmentInfo)
   // const data: QueryDatabaseResponse = await getDatabaseQuery({
   //   database_id: DATABASE_ID,
+  //   draft: isEnabled,
   //   filterType: 'starts_with',
-  //   preview,
   //   revalidate,
   //   segmentInfo: {
   //     ...segmentInfo,
@@ -35,8 +37,8 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   // })
   const data = await getDataFromCache({
     database_id: '',
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo: {
       ...segmentInfo,
@@ -71,11 +73,11 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   )
 }
 
-export default function Page({ preview = false, revalidate = false, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   // if (segmentInfo.isIndex) {
-  //   return <Listing preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  //   return <Listing revalidate={revalidate} segmentInfo={segmentInfo} />
   // }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }

--- a/sites/jeromefitzgerald.com/src/app/(notion)/people/[[...catchAll]]/People.Listing.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/people/[[...catchAll]]/People.Listing.tsx
@@ -1,6 +1,7 @@
 import { Anchor } from '@jeromefitz/ds/components/Anchor'
 import { isObjectEmpty } from '@jeromefitz/utils'
 import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
+import { draftMode } from 'next/headers'
 import { notFound } from 'next/navigation'
 
 import { getDataFromCache } from '~app/(cache)'
@@ -55,13 +56,14 @@ function ListingTemp({ data }) {
 
 // @todo(complexity) 11
 // eslint-disable-next-line complexity
-async function Listing({ preview, revalidate, segmentInfo }) {
+async function Listing({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   // const { slug } = segmentInfo
   // @note(notion) Listing do not pass Database ID
   const data = await getDataFromCache({
     database_id: '',
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo,
   })
@@ -97,7 +99,9 @@ async function Listing({ preview, revalidate, segmentInfo }) {
    */
   const personData: QueryDatabaseResponse = await getDatabaseQuery({
     database_id: DATABASE_ID,
+    draft: isEnabled,
     filterType: 'starts_with',
+    revalidate,
     segmentInfo,
   })
   const hasData = personData?.results?.length > 0

--- a/sites/jeromefitzgerald.com/src/app/(notion)/people/[[...catchAll]]/Person.Slug.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/people/[[...catchAll]]/Person.Slug.tsx
@@ -1,4 +1,5 @@
 import { isObjectEmpty } from '@jeromefitz/utils'
+import { draftMode } from 'next/headers'
 import { notFound } from 'next/navigation'
 
 import { getDataFromCache } from '~app/(cache)'
@@ -28,11 +29,12 @@ const RELATIONS: RELATIONS_TYPE[] = [
 
 const { DATABASE_ID } = CONSTANTS.PEOPLE
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   const data = await getDataFromCache({
     database_id: DATABASE_ID,
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo,
   })

--- a/sites/jeromefitzgerald.com/src/app/(notion)/people/[[...catchAll]]/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/people/[[...catchAll]]/page.tsx
@@ -1,6 +1,6 @@
 import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
-import isEqual from 'lodash/isEqual'
-import uniqWith from 'lodash/uniqWith'
+// import isEqual from 'lodash/isEqual'
+// import uniqWith from 'lodash/uniqWith'
 import type { Metadata } from 'next'
 
 import { getDataFromCache } from '~app/(cache)'
@@ -56,7 +56,9 @@ async function _generateStaticParams({ ...props }) {
   // })
   const dataStatic: QueryDatabaseResponse = await getDatabaseQuery({
     database_id: DATABASE_ID,
+    draft: false,
     filterType: 'starts_with',
+    revalidate: false,
     segmentInfo,
   })
   const hasContent = dataStatic?.results?.length > 0
@@ -86,9 +88,9 @@ async function _generateStaticParams({ ...props }) {
       }
     })
   }
-  const routes = !!combos && uniqWith(combos, isEqual)
-  !!routes && console.dir(`routes: turned off for now`)
-  !!routes && console.dir(routes)
+  // const routes = !!combos && uniqWith(combos, isEqual)
+  // !!routes && console.dir(`routes: turned off for now`)
+  // !!routes && console.dir(routes)
   // !!routes && routes.map((route) => segments.push(route))
 
   // console.dir(segments)
@@ -101,13 +103,11 @@ async function _generateStaticParams({ ...props }) {
 const generateStaticParams = isDev ? undefined : _generateStaticParams
 // export { generateStaticParams }
 
-export default function Page({ preview = false, revalidate = false, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   if (segmentInfo.isIndex) {
-    return (
-      <Listing preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
-    )
+    return <Listing revalidate={revalidate} segmentInfo={segmentInfo} />
   }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }

--- a/sites/jeromefitzgerald.com/src/app/(notion)/podcasts/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/podcasts/page.tsx
@@ -3,6 +3,7 @@
  */
 import { isObjectEmpty } from '@jeromefitz/utils'
 // import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
+import { draftMode } from 'next/headers'
 
 import { getDataFromCache } from '~app/(cache)'
 import { CONSTANTS } from '~app/(notion)/(config)/constants'
@@ -21,12 +22,13 @@ import { Testing } from '~components/Testing'
 
 const { SEGMENT } = CONSTANTS.PODCASTS
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   // console.dir(segmentInfo)
   // const data: QueryDatabaseResponse = await getDatabaseQuery({
   //   database_id: DATABASE_ID,
+  //   draft: isEnabled,
   //   filterType: 'starts_with',
-  //   preview,
   //   revalidate,
   //   segmentInfo: {
   //     ...segmentInfo,
@@ -35,8 +37,8 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   // })
   const data = await getDataFromCache({
     database_id: '',
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo: {
       ...segmentInfo,
@@ -71,11 +73,11 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   )
 }
 
-export default function Page({ preview = false, revalidate = false, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   // if (segmentInfo.isIndex) {
-  //   return <Listing preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  //   return <Listing revalidate={revalidate} segmentInfo={segmentInfo} />
   // }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }

--- a/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/Show.Slug.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/Show.Slug.tsx
@@ -1,4 +1,5 @@
 import { isObjectEmpty } from '@jeromefitz/utils'
+import { draftMode } from 'next/headers'
 import { notFound } from 'next/navigation'
 
 import { getDataFromCache } from '~app/(cache)'
@@ -39,11 +40,14 @@ const RELATIONS: RELATIONS_TYPE[] = [
   // 'Relation.Events.Primary',
 ]
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
+  // console.dir(`Slug: segmentInfo => draft: ${isEnabled ? 'y' : 'n'}`)
+  // console.dir(segmentInfo)
   const data = await getDataFromCache({
     database_id: DATABASE_ID,
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo,
   })

--- a/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/page.tsx
@@ -48,19 +48,6 @@ export async function generateMetadata({ ...props }): Promise<Metadata> {
   return isPublished ? data?.seo : is404Seo
 }
 
-// const mockStaticParamsTest = [
-//   { catchAll: ['jerome-and'] },
-//   { catchAll: ['knights-of-the-arcade'] },
-//   { catchAll: ['the-playlist'] },
-//   { catchAll: ['warp-zone'] },
-// ]
-
-// export function generateStaticParams() {
-//   console.dir(`> generateStaticParams`)
-//   console.dir(mockStaticParamsTest)
-//   return mockStaticParamsTest
-// }
-
 async function _generateStaticParams({ ...props }) {
   if (isDev) {
     return []
@@ -78,7 +65,9 @@ async function _generateStaticParams({ ...props }) {
   // })
   const dataStatic: QueryDatabaseResponse = await getDatabaseQuery({
     database_id: DATABASE_ID,
+    draft: false,
     filterType: 'starts_with',
+    revalidate: false,
     segmentInfo,
   })
   const hasContent = dataStatic?.results?.length > 0
@@ -113,20 +102,18 @@ async function _generateStaticParams({ ...props }) {
   !!routes && console.dir(routes)
   // !!routes && routes.map((route) => segments.push(route))
 
-  console.dir(segments)
+  // console.dir(segments)
 
   return segments
 }
 const generateStaticParams = isDev ? undefined : _generateStaticParams
 export { generateStaticParams }
 
-export default function Page({ preview = false, revalidate = false, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   if (segmentInfo.isIndex) {
-    return (
-      <Listing preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
-    )
+    return <Listing revalidate={revalidate} segmentInfo={segmentInfo} />
   }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }

--- a/sites/jeromefitzgerald.com/src/app/api/v1/draft-disable/route.ts
+++ b/sites/jeromefitzgerald.com/src/app/api/v1/draft-disable/route.ts
@@ -1,0 +1,6 @@
+import { draftMode } from 'next/headers'
+
+export function GET() {
+  draftMode().disable()
+  return new Response('Draft mode is disabled')
+}

--- a/sites/jeromefitzgerald.com/src/app/api/v1/draft/route.ts
+++ b/sites/jeromefitzgerald.com/src/app/api/v1/draft/route.ts
@@ -1,0 +1,74 @@
+import { draftMode } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { getDataFromCache } from '~app/(cache)'
+import { getSegmentInfo } from '~app/(notion)/(config)/utils'
+
+/**
+ * @todo(notion) this is a proof of concept right now
+ */
+function getSegmentFromSlug(slug) {
+  const split = slug.split('/')
+  if (
+    split[1] === 'blog' ||
+    split[1] === 'books' ||
+    // split[1] === 'episodes' ||
+    split[1] === 'events' ||
+    split[1] === 'people' ||
+    split[1] === 'podcasts' ||
+    split[1] === 'shows' ||
+    split[1] === 'venues'
+  ) {
+    return split[1]
+  }
+  return 'pages'
+}
+
+export async function GET(request: Request) {
+  // Parse query string parameters
+  const { searchParams } = new URL(request.url)
+  const secret = searchParams.get('secret')
+  const slug = searchParams.get('slug') ?? ''
+
+  if (secret !== process.env.DRAFT_TOKEN || !slug) {
+    return new Response('Invalid token', { status: 401 })
+  }
+
+  if (slug[0] !== '/') {
+    return new Response('Bad request', { status: 400 })
+  }
+
+  const SEGMENT = getSegmentFromSlug(slug)
+  const segmentInfo = getSegmentInfo({
+    SEGMENT,
+    params: { catchAll: [slug.split('/')[2]] },
+  })
+  // console.dir(`(draft) segmentInfo:`)
+  // console.dir(segmentInfo)
+
+  // @todo(notion) homepage of `/`
+  // console.dir(slug.split('/'))
+  const slugTemp = SEGMENT === 'pages' ? `/${slug.split('/')[2]}` : slug
+  // console.dir(`(draft) slugTemp: ${slugTemp}`)
+
+  const data = await getDataFromCache({
+    database_id: '',
+    draft: true,
+    filterType: 'equals',
+    revalidate: false,
+    segmentInfo: segmentInfo.isIndex
+      ? {
+          ...segmentInfo,
+          slug: slugTemp,
+        }
+      : { ...segmentInfo },
+  })
+
+  if (!data) {
+    return new Response('Invalid slug', { status: 401 })
+  }
+
+  draftMode().enable()
+
+  redirect(slug)
+}

--- a/sites/jeromefitzgerald.com/src/app/api/v1/revalidate/route.ts
+++ b/sites/jeromefitzgerald.com/src/app/api/v1/revalidate/route.ts
@@ -103,16 +103,16 @@ export async function POST(request: NextRequest) {
     if (segmentInfo.isIndex) {
       data = await getDataFromCache({
         database_id: '', // do not pass database
+        draft: false,
         filterType: 'equals',
-        preview: false,
         revalidate: true,
         segmentInfo: { ...segmentInfo, slug: route === '/' ? '/homepage' : route },
       })
     } else {
       data = await getDataFromCache({
         database_id,
+        draft: false,
         filterType: 'equals',
-        preview: false,
         revalidate: true,
         segmentInfo,
       })

--- a/sites/jeromefitzgerald.com/src/app/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/page.tsx
@@ -4,6 +4,7 @@
 import { isObjectEmpty } from '@jeromefitz/utils'
 // import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
 import type { Metadata } from 'next'
+import { draftMode } from 'next/headers'
 
 import { getDataFromCache } from '~app/(cache)'
 import { CONSTANTS } from '~app/(notion)/(config)/constants'
@@ -24,12 +25,14 @@ import { Testing } from '~components/Testing'
 const { SEGMENT } = CONSTANTS.PAGES
 
 export async function generateMetadata({ ...props }): Promise<Metadata> {
+  const { isEnabled } = draftMode()
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
   const data = await getDataFromCache({
     database_id: '',
+    draft: isEnabled,
     filterType: 'equals',
-    // preview,
-    // revalidate,
+    // @todo(next) revalidate
+    revalidate: false,
     segmentInfo: {
       ...segmentInfo,
       slug: '/homepage',
@@ -49,11 +52,14 @@ export async function generateMetadata({ ...props }): Promise<Metadata> {
   return isPublished ? data?.seo : is404Seo
 }
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   // console.dir(segmentInfo)
   // const data: QueryDatabaseResponse = await getDatabaseQuery({
   //   database_id: DATABASE_ID,
+  //   draft: isEnabled,
   //   filterType: 'starts_with',
+  //   revalidate,
   //   segmentInfo: {
   //     ...segmentInfo,
   //     slug: '/homepage',
@@ -61,8 +67,8 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   // })
   const data = await getDataFromCache({
     database_id: '',
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo: {
       ...segmentInfo,
@@ -96,11 +102,11 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   )
 }
 
-export default function Page({ preview = false, revalidate = false, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   // if (segmentInfo.isIndex) {
-  //   return <Listing segmentInfo={segmentInfo} />
+  //   return <Listing revalidate={revalidate} segmentInfo={segmentInfo} />
   // }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }

--- a/sites/jeromefitzgerald.com/src/app/playground/kitchen-sink/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/kitchen-sink/page.tsx
@@ -3,6 +3,7 @@
  */
 import { isObjectEmpty } from '@jeromefitz/utils'
 // import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
+import { draftMode } from 'next/headers'
 
 import { getDataFromCache } from '~app/(cache)'
 import { CONSTANTS } from '~app/(notion)/(config)/constants'
@@ -22,11 +23,14 @@ import {
 
 const { SEGMENT } = CONSTANTS.PAGES
 
-async function Slug({ preview, revalidate, segmentInfo }) {
+async function Slug({ revalidate, segmentInfo }) {
+  const { isEnabled } = draftMode()
   // console.dir(segmentInfo)
   // const data: QueryDatabaseResponse = await getDatabaseQuery({
   //   database_id: DATABASE_ID,
+  //   draft: isEnabled,
   //   filterType: 'starts_with',
+  //   revalidate,
   //   segmentInfo: {
   //     ...segmentInfo,
   //     slug: '/homepage',
@@ -34,8 +38,8 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   // })
   const data = await getDataFromCache({
     database_id: '',
+    draft: isEnabled,
     filterType: 'equals',
-    preview,
     revalidate,
     segmentInfo: {
       ...segmentInfo,
@@ -68,11 +72,11 @@ async function Slug({ preview, revalidate, segmentInfo }) {
   )
 }
 
-export default function Page({ preview = false, revalidate = false, ...props }) {
+export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   // if (segmentInfo.isIndex) {
-  //   return <Listing segmentInfo={segmentInfo} />
+  //   return <Listing revalidate={revalidate} segmentInfo={segmentInfo} />
   // }
-  return <Slug preview={preview} revalidate={revalidate} segmentInfo={segmentInfo} />
+  return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />
 }


### PR DESCRIPTION
Change from `preview` to `draft`
- ref: https://nextjs.org/docs/app/building-your-application/configuring/draft-mode

To-Do:
- [x] `draftMode`
- [x] `draft` get from `datasource`, do not `setCache`
- [x] "fix" `revalidate` with cache wrapper 

Note:

- This does not currently work for any `pages` segment in root.