### PR TITLE
🐛  (analytics) vercel/fathom; NEXT_DYNAMIC_NO_SSR_CODE [b]

### DIFF
--- a/packages/shared/src/components/Analytics/Analytics.tsx
+++ b/packages/shared/src/components/Analytics/Analytics.tsx
@@ -1,4 +1,5 @@
-'use client'
+import { Suspense } from 'react'
+
 import { FathomAnalytics } from './Fathom'
 import { VercelAnalytics } from './Vercel'
 
@@ -6,7 +7,9 @@ function Analytics() {
   return (
     <>
       <VercelAnalytics />
-      <FathomAnalytics />
+      <Suspense>
+        <FathomAnalytics />
+      </Suspense>
     </>
   )
 }

--- a/packages/shared/src/components/Analytics/Vercel.tsx
+++ b/packages/shared/src/components/Analytics/Vercel.tsx
@@ -1,4 +1,3 @@
-'use client'
 import { Analytics } from '@vercel/analytics/react'
 
 const debug = process.env.NODE_ENV === 'development'

--- a/sites/jeromefitzgerald.com/src/app/(notion)/people/[[...catchAll]]/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/people/[[...catchAll]]/page.tsx
@@ -47,6 +47,9 @@ export async function generateMetadata({ ...props }): Promise<Metadata> {
     : { title: `404 | ${segmentInfo?.segment} | ${process.env.NEXT_PUBLIC__SITE}` }
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function _generateStaticParams({ ...props }) {
   // @todo(types)
   const segments: any = [{ catchAll: [] }]
@@ -102,11 +105,10 @@ async function _generateStaticParams({ ...props }) {
 
   return segments
 }
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const generateStaticParams = isDev ? undefined : _generateStaticParams
-// export { generateStaticParams }
+
+// const generateStaticParams = isDev ? undefined : _generateStaticParams
+const generateStaticParams = isDev ? undefined : undefined
+export { generateStaticParams }
 
 export default function Page({ revalidate = false, ...props }) {
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })

--- a/sites/jeromefitzgerald.com/src/app/layout.tsx
+++ b/sites/jeromefitzgerald.com/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { cx } from '@jeromefitz/ds/utils/cx'
 import { Analytics } from '@jeromefitz/shared/src/components/Analytics'
 import dynamic from 'next/dynamic'
 import localFont from 'next/font/local'
-import { Fragment, Suspense } from 'react'
+import { Fragment } from 'react'
 
 import { Banner } from '~components/Banner'
 import { Providers } from '~components/Providers'
@@ -142,10 +142,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         )}
       >
         <Providers>
-          <Suspense>
-            <Analytics />
-          </Suspense>
-          {/* <Analytics /> */}
+          <Analytics />
           <Banner />
           <Main>{children}</Main>
           <Wrapper>

--- a/sites/jeromefitzgerald.com/src/app/layout.tsx
+++ b/sites/jeromefitzgerald.com/src/app/layout.tsx
@@ -9,24 +9,17 @@ import { Fragment } from 'react'
 import { Banner } from '~components/Banner'
 import { Providers } from '~components/Providers'
 
-// const Analytics = dynamic(
-//   () =>
-//     import('@jeromefitz/shared/src/components/Analytics').then(
-//       (mod) => mod.Analytics
-//     ),
-//   { ssr: true }
-// )
 // const Footer = dynamic(
 //   () => import('~components/Footer').then((mod) => mod.Footer),
-//   { ssr: true }
+//   { ssr: false }
 // )
 // const NowPlaying = dynamic(
 //   () => import('~components/NowPlaying').then((mod) => mod.NowPlaying),
-//   { ssr: true }
+//   { ssr: false }
 // )
 // const NowReading = dynamic(
 //   () => import('~components/NowReading').then((mod) => mod.NowReading),
-//   { ssr: true }
+//   { ssr: false }
 // )
 // const Analytics = dynamic(
 //   async () => {
@@ -42,21 +35,21 @@ const Footer = dynamic(
     const { Footer: Component } = await import('~components/Footer')
     return { default: Component }
   },
-  { ssr: true }
+  { ssr: false }
 )
 const NowPlaying = dynamic(
   async () => {
     const { NowPlaying: Component } = await import('~components/NowPlaying')
     return { default: Component }
   },
-  { ssr: true }
+  { ssr: false }
 )
 const NowReading = dynamic(
   async () => {
     const { NowReading: Component } = await import('~components/NowReading')
     return { default: Component }
   },
-  { ssr: true }
+  { ssr: false }
 )
 
 const fontSans = localFont({

--- a/sites/jeromefitzgerald.com/src/app/playground/design-system/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/design-system/page.tsx
@@ -8,7 +8,7 @@ const PlaygroundPage = dynamic(
     const { PlaygroundPage: Component } = await import('~components/Playground')
     return { default: Component }
   },
-  { ssr: true }
+  { ssr: false }
 )
 
 const isDev = process.env.NODE_ENV === 'development'

--- a/sites/jeromefitzgerald.com/src/app/playground/design-system/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/design-system/page.tsx
@@ -1,8 +1,7 @@
 import dynamic from 'next/dynamic'
-import { notFound } from 'next/navigation'
-// import { PlaygroundPage } from '~components/Playground'
+// import { notFound } from 'next/navigation'
 
-const isDev = process.env.NODE_ENV === 'development'
+import { FourOhFour } from '~app/_errors/404'
 
 const PlaygroundPage = dynamic(
   async () => {
@@ -12,8 +11,13 @@ const PlaygroundPage = dynamic(
   { ssr: true }
 )
 
+const isDev = process.env.NODE_ENV === 'development'
+
 export default function Page() {
-  if (!isDev) notFound()
+  // if (!isDev) notFound()
+  // @note(next) avoid NEXT_DYNAMIC_NO_SSR_CODE
+  if (!isDev) return <FourOhFour isNotPublished={false} segmentInfo={{}} />
+
   return (
     <>
       <PlaygroundPage />

--- a/sites/jeromefitzgerald.com/src/app/playground/kitchen-sink/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/kitchen-sink/page.tsx
@@ -13,9 +13,10 @@ import {
 } from '@jeromefitz/shared/src/notion/utils'
 import { isObjectEmpty } from '@jeromefitz/utils'
 import { draftMode } from 'next/headers'
-import { notFound } from 'next/navigation'
+// import { notFound } from 'next/navigation'
 
 import { CONFIG, getPageData } from '~app/(notion)/_config'
+import { FourOhFour } from '~app/_errors/404'
 import { Notion as Blocks } from '~components/Notion'
 
 const isDev = process.env.NODE_ENV === 'development'
@@ -55,7 +56,9 @@ async function Slug({ revalidate, segmentInfo }) {
 }
 
 export default function Page({ revalidate = false, ...props }) {
-  if (!isDev) notFound()
+  // if (!isDev) notFound()
+  // @note(next) avoid NEXT_DYNAMIC_NO_SSR_CODE
+  if (!isDev) return <FourOhFour isNotPublished={false} segmentInfo={{}} />
   const segmentInfo = getSegmentInfo({ SEGMENT, ...props })
 
   return <Slug revalidate={revalidate} segmentInfo={segmentInfo} />

--- a/sites/jeromefitzgerald.com/src/app/playground/open-graph/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/open-graph/page.tsx
@@ -7,7 +7,9 @@ import {
   // Tags,
 } from '@jeromefitz/ds/components/Section'
 import { cx } from '@jeromefitz/ds/utils/cx'
-import { notFound } from 'next/navigation'
+// import { notFound } from 'next/navigation'
+
+import { FourOhFour } from '~app/_errors/404'
 
 const isDev = process.env.NODE_ENV === 'development'
 
@@ -116,7 +118,9 @@ function OpenGraphTesting() {
 }
 
 export default function Page() {
-  if (!isDev) notFound()
+  // if (!isDev) notFound()
+  // @note(next) avoid NEXT_DYNAMIC_NO_SSR_CODE
+  if (!isDev) return <FourOhFour isNotPublished={false} segmentInfo={{}} />
   return (
     <>
       <SectionWrapper>

--- a/sites/jeromefitzgerald.com/src/app/playground/plaiceholder/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/plaiceholder/page.tsx
@@ -8,7 +8,9 @@ import {
   // Tags,
 } from '@jeromefitz/ds/components/Section'
 import Image from 'next/image'
-import { notFound } from 'next/navigation'
+// import { notFound } from 'next/navigation'
+
+import { FourOhFour } from '~app/_errors/404'
 
 const isDev = process.env.NODE_ENV === 'development'
 
@@ -42,7 +44,9 @@ async function ImageTest() {
 }
 
 export default function Page() {
-  if (!isDev) notFound()
+  // if (!isDev) notFound()
+  // @note(next) avoid NEXT_DYNAMIC_NO_SSR_CODE
+  if (!isDev) return <FourOhFour isNotPublished={false} segmentInfo={{}} />
   const title = 'Plaiceholder'
 
   return (

--- a/sites/jeromefitzgerald.com/src/components/Notion/Notion.Config.ts
+++ b/sites/jeromefitzgerald.com/src/components/Notion/Notion.Config.ts
@@ -17,7 +17,7 @@ const custom = {
           (mod) => mod.Embed
         ),
       {
-        ssr: true,
+        ssr: false,
       }
     ),
     // component: lazy(() => import('@jeromefitz/shared/src/components/Notion/Blocks/Embed')),
@@ -38,7 +38,7 @@ const custom = {
           (mod) => mod.Video
         ),
       {
-        ssr: true,
+        ssr: false,
       }
     ),
     // component: lazy(() => import('@jeromefitz/shared/src/components/Notion/Blocks/Video')),

--- a/sites/jeromefitzgerald.com/src/components/Providers/Providers.client.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Providers/Providers.client.tsx
@@ -15,7 +15,7 @@ const RouterEventProvider = dynamic(
     )
     return { default: Component }
   },
-  { ssr: true }
+  { ssr: false }
 )
 
 const pluralRules = [

--- a/sites/jeromefitzgerald.com/src/components/Providers/RouterEventProvider.client.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Providers/RouterEventProvider.client.tsx
@@ -11,7 +11,7 @@ const Loading = dynamic(
     )
     return { default: Component }
   },
-  { ssr: true }
+  { ssr: false }
 )
 
 function RouterEventProvider() {


### PR DESCRIPTION
- [x] 🐛  (analytics) vercel server; fathom client
  - I mean, I think, heh. Fathom works just fine. Vercel stopped after perf updates apparently
- [x] 🐛  notFound() causes NEXT_DYNAMIC_NO_SSR_CODE
  - Introduced in `nextd@13.4.10`
- [X] ♻️  return of ssr: false
  - With above `notFound` can finally tell where this warning was coming from G2G back


Aye welcome back Vercel Analytics (from Preview Environment):
<img width="74" alt="image" src="https://github.com/JeromeFitz/websites/assets/3099369/2ed84bbf-8a06-4285-a1cc-af1056d994ea">
