### PR TITLE
🔧 (next-config) NICE-64 outputFileTracingExcludes swc

### DIFF
--- a/packages/next-config/next.config.mjs
+++ b/packages/next-config/next.config.mjs
@@ -103,6 +103,14 @@ const config = ({
     experimental: {
       appDir: true,
       legacyBrowsers: false,
+      // @note(next) storybook needs this -- but nothing else.
+      outputFileTracingExcludes: {
+        '*': [
+          'node_modules/.pnpm/@swc+core-linux-x64-musl',
+          'node_modules/.pnpm/@swc+core-linux-x64-gnu',
+          'node_modules/.pnpm/@esbuild+linux-x64',
+        ],
+      },
       // @note(next) monorepo root
       outputFileTracingRoot: join(pathDirName, '../../'),
       serverComponentsExternalPackages,


### PR DESCRIPTION
Issue is storybook@7 ships with `swc` and need to exclude it since
 production does not need it and ... not sure what is happening.

```bash
Serverless Function's page: ...
Large Dependencies                                                      Uncompressed size  Compressed size
node_modules/.pnpm/@swc+core-linux-x64-musl@1.3.70                               51.77 MB         17.18 MB
node_modules/.pnpm/@swc+core-linux-x64-gnu@1.3.70                                44.48 MB         14.62 MB
node_modules/.pnpm/sharp@0.32.3                                                   16.1 MB          6.95 MB
node_modules/.pnpm/next@13.4.11-canary.1_react-dom@18.2.0_react@18.2.0           21.98 MB          5.43 MB
node_modules/.pnpm/@esbuild+linux-x64@0.18.8                                      8.77 MB          3.68 MB
node_modules/.pnpm/webpack@5.88.0_@swc+core@1.3.70                                4.05 MB         997.6 KB
node_modules/.pnpm/react-dom@18.2.0_react@18.2.0                                  1.64 MB        405.36 KB
node_modules/.pnpm/caniuse-lite@1.0.30001512                                     905.8 KB        326.36 KB
node_modules/.pnpm/uglify-js@3.17.4                                               1.13 MB        208.12 KB
node_modules/.pnpm/terser@5.18.1                                                 964.3 KB        185.13 KB
sites/jeromefitzgerald.com/.next                                                923.68 KB        162.89 KB
All dependencies                                                                 17.98 MB         50.85 MB
```