### PR TITLE
🐛  (rss) atom:self link to rss feed not href url [skip ci]

### DIFF
--- a/sites/jerandky.com/src/app/api/rss/podcasts/jer-and-ky-and-guest/route.ts
+++ b/sites/jerandky.com/src/app/api/rss/podcasts/jer-and-ky-and-guest/route.ts
@@ -21,7 +21,7 @@ export function GET() {
     <copyright><![CDATA[2023 JerKy BoyZ et Team Mail & Shrimp]]></copyright>
     <docs>https://jerandky.com</docs>
     <category><![CDATA[Comedy]]></category>
-    <atom:link rel="self" href="https://jerandky.com/podcasts/jer-and-ky-and-guest" type="application/rss+xml"/>
+    <atom:link rel="self" href="https://jerandky.com/api/rss/podcasts/jer-and-ky-and-guest" type="application/rss+xml"/>
     <language>en-US</language>
     <image>
       <url>https://cdn.jerandky.com/jerandky.com/podcasts/jer-and-ky-and-guest/season-01/_original/s01e00--000--00.jpg</url>
@@ -31,7 +31,7 @@ export function GET() {
     <itunes:author>JerKy BoyZ et Team Mail &amp; Shrimp</itunes:author>
     <itunes:subtitle>tHe bOYz</itunes:subtitle>
     <itunes:summary>Every episode is an action packed 3-5 minutes. Two Dummies (Jer &amp; Ky) + One Guest (&amp; Guest) = Four Podcasts (in one).</itunes:summary>
-    <itunes:type/>
+    <itunes:type>episodic</itunes:type>
     <itunes:owner>
       <itunes:name>JerKy BoyZ et Team Mail &amp; Shrimp</itunes:name>
       <itunes:email>jeromes+jer-and-ky@gmail.com</itunes:email>

--- a/sites/jerandky.com/src/app/api/rss/podcasts/knockoffs/route.ts
+++ b/sites/jerandky.com/src/app/api/rss/podcasts/knockoffs/route.ts
@@ -20,7 +20,7 @@ export function GET() {
     <copyright><![CDATA[2023 JerKy BoyZ et Knockoffs]]></copyright>
     <docs>https://jerandky.com</docs>
     <category><![CDATA[Comedy]]></category>
-    <atom:link rel="self" href="https://jerandky.com/podcasts/knockoffs" type="application/rss+xml"/>
+    <atom:link rel="self" href="https://jerandky.com/api/rss/podcasts/knockoffs" type="application/rss+xml"/>
     <language>en-US</language>
     <image>
       <url>https://cdn.jerandky.com/jerandky.com/podcasts/knockoffs/season-01/_original/knockoffs--s01e00--cover-art--final.jpg</url>
@@ -30,7 +30,7 @@ export function GET() {
     <itunes:author>JerKy BoyZ et Knockoffs</itunes:author>
     <itunes:subtitle>Just two jerks talking like jerks</itunes:subtitle>
     <itunes:summary>Each week Alex &amp; Kyle discuss a (classic?) movie and do their best to focus on its shortcomings. Horror movies, thrillers, teens-in-the-woods… Anything goes, as long as someone gets knocked off.</itunes:summary>
-    <itunes:type/>
+    <itunes:type>episodic</itunes:type>
     <itunes:owner>
       <itunes:name>JerKy BoyZ et Knockoffs</itunes:name>
       <itunes:email>jeromes+knockoffs@gmail.com</itunes:email>

--- a/sites/jeromefitzgerald.com/src/app/api/rss/podcasts/[slug]/route.ts
+++ b/sites/jeromefitzgerald.com/src/app/api/rss/podcasts/[slug]/route.ts
@@ -103,6 +103,7 @@ export async function GET(
       {
         'atom:link': {
           _attr: {
+            // @todo(rss) this is the RSS FEED not the SITE URL
             href: siteUrl,
             rel: 'self',
             type: 'application/rss+xml',


### PR DESCRIPTION
- [x] 📝 Make note whenever this needs to be dynamically generated again
- [x] 🐛 Update the hard-coded places
- [x] 🚀 Separately ship outside of GitHub CI/CD
- [x] ✅ Validate on: `https://castfeedvalidator.com/` 
 