### PR TITLE
♻️  (radix-ui) NICE-86 direct esm imports to reduce js [b]

### DIFF
--- a/packages/design-system/src/components/Anchor/Anchor.tsx
+++ b/packages/design-system/src/components/Anchor/Anchor.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@radix-ui/themes'
+import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
 // eslint-disable-next-line no-restricted-imports
 import NextLink, { type LinkProps } from 'next/link'
 import React, { type PropsWithChildren } from 'react'

--- a/packages/design-system/src/components/Callout/Callout.tsx
+++ b/packages/design-system/src/components/Callout/Callout.tsx
@@ -1,7 +1,11 @@
 import type { CalloutRootProps } from '@radix-ui/themes/dist/esm/components/callout.js'
 import type { ReactNode } from 'react'
 
-import { CalloutIcon, CalloutRoot, CalloutText } from '@radix-ui/themes'
+import {
+  CalloutIcon,
+  CalloutRoot,
+  CalloutText,
+} from '@radix-ui/themes/dist/esm/components/callout.js'
 
 import { cx } from '../../utils/cx'
 import { FileTextIcon } from '../Icon/index'

--- a/packages/shared/src/components/Notion/Blocks/Image.client.tsx
+++ b/packages/shared/src/components/Notion/Blocks/Image.client.tsx
@@ -1,6 +1,7 @@
 /**
  * @todo(types) next/image
  */
+// import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import NextImage from 'next/image'
@@ -32,15 +33,42 @@ function Image({ ...props }) {
     ...img,
   }
 
-  // console.dir(`imageProps`)
-  // console.dir(imageProps)
+  // // console.dir(`imageProps`)
+  // // console.dir(imageProps)
+
+  // const testProps = {
+  //   alt: imageProps.alt,
+  //   blurDataURL: imageProps.blurDataURL,
+  //   fetchPriority: imageProps.fetchPriority,
+  //   priority: imageProps.priority,
+  //   quality: imageProps.quality,
+  //   // sizes: imageProps.sizes,
+  //   src: imageProps.src,
+  // }
+
+  // // console.dir(`testProps`)
+  // // console.dir(testProps)
 
   return (
-    <NextImage
-      className="flex w-full justify-center rounded"
-      placeholder="blur"
-      {...imageProps}
-    />
+    <>
+      <NextImage
+        className="flex w-full justify-center rounded-[var(--radius-3)]"
+        placeholder="blur"
+        {...imageProps}
+      />
+      {/* <Box
+        height="100%"
+        maxWidth={{ initial: '100%', lg: '1024px', md: '768px', xl: '1280px' }}
+        position="relative"
+      >
+        <NextImage
+          className="rounded-[var(--radius-3)]"
+          fill={true}
+          placeholder="blur"
+          {...testProps}
+        />
+      </Box> */}
+    </>
   )
 }
 

--- a/sites/jeromefitzgerald.com/src/app/(notion)/about/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/about/page.tsx
@@ -6,7 +6,7 @@ import { isObjectEmpty } from '@jeromefitz/utils'
 
 import type { Metadata } from 'next'
 
-import { Text } from '@radix-ui/themes'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import { draftMode } from 'next/headers.js'
 
 import { CONFIG, getPageData } from '@/app/(notion)/_config/index'

--- a/sites/jeromefitzgerald.com/src/app/(notion)/books/_components/Book.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/books/_components/Book.client.tsx
@@ -4,17 +4,15 @@ import { Callout } from '@jeromefitz/ds/components/Callout/index'
 import { lpad } from '@jeromefitz/utils'
 
 import { useScrollIntoView } from '@mantine/hooks'
-import {
-  Badge,
-  Box,
-  Button,
-  Code,
-  Flex,
-  Link,
-  Separator,
-  Strong,
-  Text,
-} from '@radix-ui/themes'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import { Code } from '@radix-ui/themes/dist/esm/components/code.js'
+import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
+import { Link } from '@radix-ui/themes/dist/esm/components/link.js'
+import { Separator } from '@radix-ui/themes/dist/esm/components/separator.js'
+import { Strong } from '@radix-ui/themes/dist/esm/components/strong.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import { format } from 'date-fns'
 import _orderBy from 'lodash/orderBy.js'
 import { Fragment } from 'react'
@@ -74,7 +72,12 @@ function Books({ data, refs }) {
           // @ts-ignore
           <Fragment key={`books-${book.id}`}>
             <Separator orientation="horizontal" ref={targetRef} size="4" />
-            <HeadlineTitle aria-label={book.title} as="h3" mb="4">
+            <HeadlineTitle
+              aria-label={book.title}
+              as="h3"
+              // className="sticky top-[calc(var(--header-height)_-_5px)] md:top-28"
+              mb="4"
+            >
               <Text as="span" id={book.id}>
                 {book.title}
               </Text>

--- a/sites/jeromefitzgerald.com/src/app/(notion)/colophon/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/colophon/page.tsx
@@ -6,7 +6,7 @@ import { isObjectEmpty } from '@jeromefitz/utils'
 
 import type { Metadata } from 'next'
 
-import { Text } from '@radix-ui/themes'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import { draftMode } from 'next/headers.js'
 
 import { CONFIG, getPageData } from '@/app/(notion)/_config/index'

--- a/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Listing.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Listing.client.tsx
@@ -6,7 +6,10 @@ import { Tags } from '@jeromefitz/ds/components/Section/index'
 import { cx } from '@jeromefitz/ds/utils/cx'
 
 import * as Accordion from '@radix-ui/react-accordion'
-import { Box, Button, Flex, Text } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 // eslint-disable-next-line no-restricted-imports
 import NextLink from 'next/link'
 

--- a/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Listing.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Listing.tsx
@@ -9,7 +9,8 @@ import { isObjectEmpty } from '@jeromefitz/utils'
 
 import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints.js'
 
-import { Link, Text } from '@radix-ui/themes'
+import { Link } from '@radix-ui/themes/dist/esm/components/link.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import _filter from 'lodash/filter.js'
 import _orderBy from 'lodash/orderBy.js'
 import _remove from 'lodash/remove.js'

--- a/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Slug.Venue.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Slug.Venue.tsx
@@ -1,6 +1,8 @@
 import { getPageDataFromNotion } from '@jeromefitz/shared/notion/utils/index'
 
-import { Flex, Skeleton, Text } from '@radix-ui/themes'
+import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
+import { Skeleton } from '@radix-ui/themes/dist/esm/components/skeleton.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import { Suspense } from 'react'
 
 import type { PageObjectResponseVenue } from '@/app/(notion)/_config/index'

--- a/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Slug.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Slug.tsx
@@ -9,7 +9,12 @@ import { Separator } from '@jeromefitz/ds/components/Separator/index'
 import { getDataFromCache } from '@jeromefitz/shared/notion/utils/index'
 import { isObjectEmpty } from '@jeromefitz/utils'
 
-import { Badge, Button, Code, Flex, Heading, Text } from '@radix-ui/themes'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import { Code } from '@radix-ui/themes/dist/esm/components/code.js'
+import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
+import { Heading } from '@radix-ui/themes/dist/esm/components/heading.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import { draftMode } from 'next/headers.js'
 import { notFound } from 'next/navigation.js'
 

--- a/sites/jeromefitzgerald.com/src/app/(notion)/music/_components/Music.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/music/_components/Music.client.tsx
@@ -8,20 +8,16 @@ import { fetcher } from '@jeromefitz/shared/lib'
 
 import { useScrollIntoView } from '@mantine/hooks'
 import { ArrowUpIcon } from '@radix-ui/react-icons'
-import {
-  Badge,
-  Box,
-  Button,
-  Card,
-  Code,
-  // Em,
-  Flex,
-  Inset,
-  Link,
-  Select,
-  // Strong,
-  Text,
-} from '@radix-ui/themes'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import { Card } from '@radix-ui/themes/dist/esm/components/card.js'
+import { Code } from '@radix-ui/themes/dist/esm/components/code.js'
+import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
+import { Inset } from '@radix-ui/themes/dist/esm/components/inset.js'
+import { Link } from '@radix-ui/themes/dist/esm/components/link.js'
+import * as Select from '@radix-ui/themes/dist/esm/components/select.parts.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import Image from 'next/image'
 // eslint-disable-next-line no-restricted-imports
 import NextLink from 'next/link'

--- a/sites/jeromefitzgerald.com/src/app/(notion)/podcasts/[[...catchAll]]/_components/Episode.Slug.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/podcasts/[[...catchAll]]/_components/Episode.Slug.tsx
@@ -6,7 +6,12 @@ import { EmbedSpotify } from '@jeromefitz/shared/components/Notion/Blocks/Embed.
 import { getDataFromCache } from '@jeromefitz/shared/notion/utils/index'
 import { isObjectEmpty } from '@jeromefitz/utils'
 
-import { Box, Flex, Grid as GridRadix, Link, Strong, Text } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
+import { Grid as GridRadix } from '@radix-ui/themes/dist/esm/components/grid.js'
+import { Link } from '@radix-ui/themes/dist/esm/components/link.js'
+import { Strong } from '@radix-ui/themes/dist/esm/components/strong.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import { draftMode } from 'next/headers.js'
 import { notFound } from 'next/navigation.js'
 

--- a/sites/jeromefitzgerald.com/src/app/(notion)/podcasts/[[...catchAll]]/_components/Podcast.Listing.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/podcasts/[[...catchAll]]/_components/Podcast.Listing.tsx
@@ -8,7 +8,8 @@ import { isObjectEmpty } from '@jeromefitz/utils'
 
 import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints.js'
 
-import { Box, Link } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Link } from '@radix-ui/themes/dist/esm/components/link.js'
 import _filter from 'lodash/filter.js'
 import _orderBy from 'lodash/orderBy.js'
 import { draftMode } from 'next/headers.js'

--- a/sites/jeromefitzgerald.com/src/app/(notion)/podcasts/[[...catchAll]]/_components/Podcast.Slug.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/podcasts/[[...catchAll]]/_components/Podcast.Slug.tsx
@@ -3,7 +3,8 @@ import { Separator } from '@jeromefitz/ds/components/Separator/index'
 import { getDataFromCache } from '@jeromefitz/shared/notion/utils/index'
 import { isObjectEmpty } from '@jeromefitz/utils'
 
-import { Badge, Code } from '@radix-ui/themes'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Code } from '@radix-ui/themes/dist/esm/components/code.js'
 import { draftMode } from 'next/headers.js'
 import { notFound } from 'next/navigation.js'
 

--- a/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/_components/Show.Listing.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/_components/Show.Listing.tsx
@@ -8,7 +8,9 @@ import { isObjectEmpty } from '@jeromefitz/utils'
 
 import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints.js'
 
-import { Box, Link, Text } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Link } from '@radix-ui/themes/dist/esm/components/link.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import _filter from 'lodash/filter.js'
 import _orderBy from 'lodash/orderBy.js'
 import { draftMode } from 'next/headers.js'

--- a/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/_components/Show.Slug.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/_components/Show.Slug.tsx
@@ -1,7 +1,9 @@
 import { getDataFromCache } from '@jeromefitz/shared/notion/utils/index'
 import { isObjectEmpty } from '@jeromefitz/utils'
 
-import { Badge, Code, Separator } from '@radix-ui/themes'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Code } from '@radix-ui/themes/dist/esm/components/code.js'
+import { Separator } from '@radix-ui/themes/dist/esm/components/separator.js'
 import { draftMode } from 'next/headers.js'
 import { notFound } from 'next/navigation.js'
 

--- a/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/_components/Show.UpcomingShows.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/_components/Show.UpcomingShows.tsx
@@ -2,7 +2,10 @@ import { AnchorUnstyled as Anchor } from '@jeromefitz/ds/components/Anchor/index
 import { cx } from '@jeromefitz/ds/utils/cx'
 import { getPageDataFromNotion } from '@jeromefitz/shared/notion/utils/index'
 
-import { Box, Heading, Link, Text } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Heading } from '@radix-ui/themes/dist/esm/components/heading.js'
+import { Link } from '@radix-ui/themes/dist/esm/components/link.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import _size from 'lodash/size.js'
 import { Suspense } from 'react'
 

--- a/sites/jeromefitzgerald.com/src/app/_components/Page.Home.tsx
+++ b/sites/jeromefitzgerald.com/src/app/_components/Page.Home.tsx
@@ -3,7 +3,11 @@ import { CameraIcon } from '@jeromefitz/ds/components/Icon/index'
 import { cx } from '@jeromefitz/ds/utils/cx'
 import { ImageClient as NextImage } from '@jeromefitz/shared/components/Notion/Blocks/Image.client'
 
-import { AspectRatio, Badge, Box, Code, Text } from '@radix-ui/themes'
+import { AspectRatio } from '@radix-ui/themes/dist/esm/components/aspect-ratio.js'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Code } from '@radix-ui/themes/dist/esm/components/code.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import { forwardRef } from 'react'
 
 import { Grid } from '@/components/Grid/index'
@@ -45,6 +49,7 @@ const PageHome = forwardRef(function PageHome(props, forwardedRef) {
   const title = 'Jerome Fitzgerald'
   return (
     <Grid ref={forwardedRef}>
+      {/* <Grid> */}
       <HeadlineColumnA>
         <HeadlineTitle aria-label={title} as="h1">
           <>

--- a/sites/jeromefitzgerald.com/src/app/_errors/404.tsx
+++ b/sites/jeromefitzgerald.com/src/app/_errors/404.tsx
@@ -1,16 +1,14 @@
 import { AnchorUnstyled as Anchor } from '@jeromefitz/ds/components/Anchor/index'
 import { isObjectEmpty } from '@jeromefitz/utils'
 
-import {
-  Badge,
-  Box,
-  Code,
-  Heading,
-  Link,
-  Separator,
-  Strong,
-  Text,
-} from '@radix-ui/themes'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Code } from '@radix-ui/themes/dist/esm/components/code.js'
+import { Heading } from '@radix-ui/themes/dist/esm/components/heading.js'
+import { Link } from '@radix-ui/themes/dist/esm/components/link.js'
+import { Separator } from '@radix-ui/themes/dist/esm/components/separator.js'
+import { Strong } from '@radix-ui/themes/dist/esm/components/strong.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 
 import { Grid } from '@/components/Grid/index'
 import {

--- a/sites/jeromefitzgerald.com/src/app/_temp/Footer.Cmdk.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/_temp/Footer.Cmdk.client.tsx
@@ -2,7 +2,8 @@
 // import { Tooltip } from '@jeromefitz/ds/components/Tooltip/index'
 
 import { useOs } from '@mantine/hooks'
-import { Button, Kbd } from '@radix-ui/themes'
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import { Kbd } from '@radix-ui/themes/dist/esm/components/kbd.js'
 
 import { useStore as _useStore } from '@/store/index'
 

--- a/sites/jeromefitzgerald.com/src/app/_temp/Footer.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/_temp/Footer.client.tsx
@@ -7,7 +7,9 @@ import {
 } from '@jeromefitz/ds/components/Icon/index'
 import { cx } from '@jeromefitz/ds/utils/cx'
 
-import { Button, Text } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import dynamic from 'next/dynamic.js'
 // eslint-disable-next-line no-restricted-imports
 import NextLink from 'next/link'
@@ -53,15 +55,21 @@ function FooterClient() {
           size="1"
           variant="surface"
         >
-          <Text as="p" size="2">
-            This site is being actively developed.
-          </Text>
-          <Text as="p" size="2">
-            So though it is nowhere near perfect, it is shippable, heh.
-          </Text>
-          <Text as="p" size="2">
-            Consider this eternally under construction.
-          </Text>
+          <Box asChild display="block">
+            <Text as="span" size="2">
+              This site is being actively developed.
+            </Text>
+          </Box>
+          <Box asChild display="block">
+            <Text as="span" size="2">
+              So though it is nowhere near perfect, it is shippable, heh.
+            </Text>
+          </Box>
+          <Box asChild display="block">
+            <Text as="span" size="2">
+              Consider this eternally under construction.
+            </Text>
+          </Box>
         </Callout>
       </div>
       <div

--- a/sites/jeromefitzgerald.com/src/app/layout.tsx
+++ b/sites/jeromefitzgerald.com/src/app/layout.tsx
@@ -2,7 +2,7 @@ import { cx } from '@jeromefitz/ds/utils/cx'
 import { Analytics } from '@jeromefitz/shared/components/Analytics/Analytics'
 import '@jeromefitz/tailwind-config/styles/globals.css'
 
-import { Theme } from '@radix-ui/themes'
+import { Theme } from '@radix-ui/themes/dist/esm/components/theme.js'
 import { GeistMono as fontGeistMono } from 'geist/font/mono'
 import { GeistSans as fontGeistSans } from 'geist/font/sans'
 import { Viewport } from 'next'

--- a/sites/jeromefitzgerald.com/src/app/playground/2024/_components/Layout.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/2024/_components/Layout.tsx
@@ -1,7 +1,12 @@
 'use client'
 // import { cx } from '@jeromefitz/ds/utils/cx'
 
-import { Badge, Box, Button, Heading, Skeleton, Text } from '@radix-ui/themes'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import { Heading } from '@radix-ui/themes/dist/esm/components/heading.js'
+import { Skeleton } from '@radix-ui/themes/dist/esm/components/skeleton.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import React, { forwardRef } from 'react'
 
 import { Grid } from '@/components/Grid/index'
@@ -28,6 +33,7 @@ const Layout = forwardRef(function Layout(props, forwardedRef) {
   return (
     <>
       <Grid ref={forwardedRef}>
+        {/* <Grid> */}
         <HeadlineColumnA>
           <HeadlineTitle aria-label={title} as="h1">
             <>

--- a/sites/jeromefitzgerald.com/src/app/playground/design-system/badges/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/design-system/badges/page.tsx
@@ -1,4 +1,5 @@
-import { Badge, Text } from '@radix-ui/themes'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 
 import { FourOhFour } from '@/app/_errors/404'
 import { Grid } from '@/components/Grid/index'

--- a/sites/jeromefitzgerald.com/src/app/playground/kitchen-sink/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/kitchen-sink/page.tsx
@@ -5,7 +5,8 @@ import {
 } from '@jeromefitz/shared/notion/utils/index'
 import { isObjectEmpty } from '@jeromefitz/utils'
 
-import { Badge, Text } from '@radix-ui/themes'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import { draftMode } from 'next/headers.js'
 // import { notFound } from 'next/navigation.js'
 

--- a/sites/jeromefitzgerald.com/src/components/Banner/Banner.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Banner/Banner.tsx
@@ -11,7 +11,11 @@
  */
 import { cx } from '@jeromefitz/ds/utils/cx'
 
-import { Badge, Box, Button, Flex, Text } from '@radix-ui/themes'
+import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 // eslint-disable-next-line no-restricted-imports
 import NextLink from 'next/link'
 

--- a/sites/jeromefitzgerald.com/src/components/Cmdk/Cmdk.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Cmdk/Cmdk.tsx
@@ -4,7 +4,8 @@ import { cx } from '@jeromefitz/ds/utils/cx'
 
 import type { ReactNode } from 'react'
 
-import { Kbd, Text } from '@radix-ui/themes'
+import { Kbd } from '@radix-ui/themes/dist/esm/components/kbd.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import { Command, useCommandState } from 'cmdk'
 import { AnimatePresence, MotionProps, motion } from 'framer-motion'
 import { slug as _slug } from 'github-slugger'

--- a/sites/jeromefitzgerald.com/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/sites/jeromefitzgerald.com/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,7 +1,10 @@
 'use client'
 import type { ReactNode } from 'react'
 
-import { Heading, Link, Separator, Text } from '@radix-ui/themes'
+import { Heading } from '@radix-ui/themes/dist/esm/components/heading.js'
+import { Link } from '@radix-ui/themes/dist/esm/components/link.js'
+import { Separator } from '@radix-ui/themes/dist/esm/components/separator.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import { Component } from 'react'
 
 import { Grid } from '@/components/Grid/index'

--- a/sites/jeromefitzgerald.com/src/components/Grid/Grid.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Grid/Grid.tsx
@@ -1,7 +1,26 @@
+/**
+ * @hack(radix-ui) To side-step the Grid init issue this will be
+ *                 duplicated in Tailwind
+ */
+import { cx } from '@jeromefitz/ds/utils/cx'
+
 import type { GridProps } from '@radix-ui/themes/dist/esm/components/grid.js'
 import type { ReactNode } from 'react'
 
-import { Grid } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+/**
+ * @note(radix-ui) importing here does not tree shake yet
+ *                 full library is imported (Alert Dialog, Avatar, etc.)
+ */
+// import { Grid } from '@radix-ui/themes'
+/**
+ * @note(radix-ui) The way we are calling this component in Layout
+ *                 results in a circular reference
+ *
+ * Error: Cannot access 'gridPropDefs' before initialization
+ *
+ */
+// import { Grid } from '@radix-ui/themes/dist/esm/components/grid.js'
 import { forwardRef } from 'react'
 
 type AdditionalProps = {
@@ -9,27 +28,63 @@ type AdditionalProps = {
   className?: string
 }
 type GridImpl = GridProps & AdditionalProps
+// const GridImpl = forwardRef(function GridImpl(
+//   { children, className, ...props }: GridImpl,
+//   forwardedRef,
+// ) {
+//   return (
+//     <Grid
+//       className={className}
+//       columns="12"
+//       flow="column"
+//       gap="2"
+//       mb="1"
+//       mr="1"
+//       p={{ initial: '4', lg: '8' }}
+//       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+//       // @ts-ignore
+//       ref={forwardedRef}
+//       width="100%"
+//       {...props}
+//     >
+//       {children}
+//     </Grid>
+//   )
+// })
+
 const GridImpl = forwardRef(function GridImpl(
   { children, className, ...props }: GridImpl,
   forwardedRef,
 ) {
   return (
-    <Grid
-      className={className}
-      columns="12"
-      flow="column"
-      gap="2"
+    <Box
+      // className={cx(`grid grid-cols-12 gap-2`, className)}
+      className={cx(
+        `[--grid-template-columns:repeat(12,_minmax(0,_1fr))]`,
+        className,
+      )}
       mb="1"
       mr="1"
       p={{ initial: '4', lg: '8' }}
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       ref={forwardedRef}
+      style={{
+        alignItems: 'stretch',
+        boxSizing: 'none',
+        display: 'grid',
+        gap: 'var(--space-2)',
+        gridAutoFlow: 'column',
+        // gridTemplateColumns: 'minmax(0, 1fr)',
+        gridTemplateColumns: 'var(--grid-template-columns)',
+        gridTemplateRows: 'none',
+        justifyContent: 'flex-start',
+      }}
       width="100%"
       {...props}
     >
       {children}
-    </Grid>
+    </Box>
   )
 })
 

--- a/sites/jeromefitzgerald.com/src/components/Headline/Headline.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Headline/Headline.tsx
@@ -4,7 +4,8 @@ import type { HeadingProps } from '@radix-ui/themes/dist/esm/components/heading.
 import type { TextProps } from '@radix-ui/themes/dist/esm/components/text.js'
 import type { ReactNode } from 'react'
 
-import { Heading, Text } from '@radix-ui/themes'
+import { Heading } from '@radix-ui/themes/dist/esm/components/heading.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 
 type AdditionalProps = {
   children: ReactNode

--- a/sites/jeromefitzgerald.com/src/components/Navigation/Navigation.desktop.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Navigation/Navigation.desktop.tsx
@@ -4,7 +4,8 @@ import { CaretDownIcon, Pencil2Icon } from '@jeromefitz/ds/components/Icon/index
 import { cx } from '@jeromefitz/ds/utils/cx'
 
 import * as NavigationMenu from '@radix-ui/react-navigation-menu'
-import { Button, Text } from '@radix-ui/themes'
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 // eslint-disable-next-line no-restricted-imports
 import NextLink from 'next/link'
 import { Fragment, forwardRef, memo } from 'react'

--- a/sites/jeromefitzgerald.com/src/components/Navigation/Navigation.mobile.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Navigation/Navigation.mobile.tsx
@@ -10,7 +10,7 @@ import { cx } from '@jeromefitz/ds/utils/cx'
 
 import * as Accordion from '@radix-ui/react-accordion'
 import * as Portal from '@radix-ui/react-portal'
-import { Button } from '@radix-ui/themes'
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
 // eslint-disable-next-line no-restricted-imports
 import NextLink from 'next/link'
 import { useTheme } from 'next-themes'

--- a/sites/jeromefitzgerald.com/src/components/Quote/Quote.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Quote/Quote.tsx
@@ -1,4 +1,9 @@
-import { Box, Em, Flex, Grid, IconButton, Text } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Em } from '@radix-ui/themes/dist/esm/components/em.js'
+import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
+import { Grid } from '@radix-ui/themes/dist/esm/components/grid.js'
+import { IconButton } from '@radix-ui/themes/dist/esm/components/icon-button.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import Image from 'next/image'
 
 function Quote({ item }) {

--- a/sites/jeromefitzgerald.com/src/components/Relations/Relations.Individual.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Relations/Relations.Individual.tsx
@@ -3,16 +3,8 @@ import { AnchorUnstyled as Anchor } from '@jeromefitz/ds/components/Anchor/index
 import { getPageDataFromNotion } from '@jeromefitz/shared/notion/utils/index'
 import { asyncForEach } from '@jeromefitz/utils'
 
-import {
-  // Badge,
-  Box,
-  // Code,
-  // Flex,
-  // Link,
-  // Separator,
-  // Strong,
-  Text,
-} from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import _noop from 'lodash/noop.js'
 import _orderBy from 'lodash/orderBy.js'
 import _size from 'lodash/size.js'

--- a/sites/jeromefitzgerald.com/src/components/Relations/Relations.Loading.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Relations/Relations.Loading.tsx
@@ -1,4 +1,5 @@
-import { Box, Text } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 
 /**
  * @todo(radix) replace with Skeleton

--- a/sites/jeromefitzgerald.com/src/components/Relations/Relations.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Relations/Relations.tsx
@@ -1,15 +1,7 @@
 import { cx } from '@jeromefitz/ds/utils/cx'
 
-import {
-  // Badge,
-  Box,
-  // Code,
-  // Flex,
-  // Link,
-  // Separator,
-  // Strong,
-  Text,
-} from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import _size from 'lodash/size.js'
 import pluralize from 'pluralize'
 // import { Suspense } from 'react'

--- a/sites/jeromefitzgerald.com/src/components/Testing/Testing.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Testing/Testing.tsx
@@ -1,6 +1,8 @@
 import { AnchorUnstyled as Anchor } from '@jeromefitz/ds/components/Anchor/index'
 
-import { Box, Flex, Link } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
+import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
+import { Link } from '@radix-ui/themes/dist/esm/components/link.js'
 
 import { Grid } from '@/components/Grid/index'
 import {


### PR DESCRIPTION
Currently importing via `radix-ui/themes` imports _everything_ Which makes sense this is a `rc` and can spend time seeing
 if can help to improve tree-shaking (and export of `types` w/ `props`).

Reduce unused JavaScript: -51 KiB

Lighthouse Stats:

- Before: Potential savings of 91 KiB
- After: Potential savings of 40 KiB

♻️  NICE-86 fix p=>p issue with footer

💩  (next) NICE-86 cannot shave this image down

oh well that 14.1 KiB is more or less a white whale at this point