### PR TITLE
♻️  NICE-75 footer; md=>lg; navDesktop [b]

### DIFF
--- a/packages/design-system/src/components/Icon/Icon.tsx
+++ b/packages/design-system/src/components/Icon/Icon.tsx
@@ -158,6 +158,33 @@ const BellIcon = ({ label, ...props }: IconProps) => (
   </AccessibleIcon>
 )
 
+const BlueskyLogoIcon = ({ label, ...props }: IconProps) => (
+  <AccessibleIcon
+    label={
+      label ||
+      'An icon representing the logo of Bluesky. Which is a silhouette of a butterfly.'
+    }
+  >
+    <svg
+      className="fill:bg-black dark:fill:bg-white"
+      height="17px"
+      role="info"
+      version="1.1"
+      viewBox="0 0 568 501"
+      width="17px"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      {...props}
+    >
+      <path
+        d="M123.121 33.664C188.241 82.553 258.281 181.68 284 234.873c25.719-53.192 95.759-152.32 160.879-201.21C491.866-1.611 568-28.906 568 57.947c0 17.346-9.945 145.713-15.778 166.555-20.275 72.453-94.155 90.933-159.875 79.748C507.222 323.8 536.444 388.56 473.333 453.32c-119.86 122.992-172.272-30.859-185.702-70.281-2.462-7.227-3.614-10.608-3.631-7.733-.017-2.875-1.169.506-3.631 7.733-13.43 39.422-65.842 193.273-185.702 70.281-63.111-64.76-33.89-129.52 80.986-149.071-65.72 11.185-139.6-7.295-159.875-79.748C9.945 203.659 0 75.291 0 57.946 0-28.906 76.135-1.612 123.121 33.664Z"
+        fill="currentColor"
+        id="bluesky-icon"
+      ></path>
+    </svg>
+  </AccessibleIcon>
+)
+
 const BookmarkIcon = ({ label, ...props }: IconProps) => (
   <AccessibleIcon
     label={
@@ -955,6 +982,7 @@ export {
   ArrowTopRightIcon,
   ArrowUturnLeftIcon,
   BellIcon,
+  BlueskyLogoIcon,
   BookOpenIcon,
   BookmarkFilledIcon,
   BookmarkIcon,

--- a/packages/design-system/src/components/Icon/index.ts
+++ b/packages/design-system/src/components/Icon/index.ts
@@ -10,6 +10,7 @@ import {
   ArrowTopRightIcon,
   ArrowUturnLeftIcon,
   BellIcon,
+  BlueskyLogoIcon,
   BookOpenIcon,
   BookmarkFilledIcon,
   BookmarkIcon,
@@ -90,6 +91,7 @@ Icon.ArrowRight = ArrowRightIcon
 Icon.ArrowTopRight = ArrowTopRightIcon
 Icon.ArrowUturnLeft = ArrowUturnLeftIcon
 Icon.Bell = BellIcon
+Icon.BlueskyLogo = BlueskyLogoIcon
 Icon.Bookmark = BookmarkIcon
 Icon.BookmarkFilled = BookmarkFilledIcon
 Icon.BookOpen = BookOpenIcon

--- a/packages/next-notion/src/blocks/Emoji.client.tsx
+++ b/packages/next-notion/src/blocks/Emoji.client.tsx
@@ -44,7 +44,7 @@ async function Emoji({ character }) {
     return (
       <EmojiHtml
         emoji={character}
-        label={'no description currently for this emoji'}
+        label={'no generated description currently for this emoji'}
       />
     )
   }

--- a/packages/next-notion/src/blocks/Emoji.server.tsx
+++ b/packages/next-notion/src/blocks/Emoji.server.tsx
@@ -42,7 +42,7 @@ function Emoji({ character }) {
     return (
       <EmojiHtml
         emoji={character}
-        label={'no description currently for this emoji'}
+        label={'no generated description currently for this emoji'}
       />
     )
   }

--- a/packages/tailwind-config/styles/globals.css
+++ b/packages/tailwind-config/styles/globals.css
@@ -29,6 +29,22 @@
   font-feature-settings: 'calt', 'zero', 'cv01', 'cv02', 'cv03', 'cv04', 'cv05',
     'cv06', 'cv08', 'cv09', 'cv10', 'cv11';
   font-variation-settings: 'opsz' 32;
+
+  /* Gray 00, 100 */
+  /*  --black: '#000000; Black */
+  /*  --white: '#ffffff; White */
+
+  /* Gray 01, 99 */
+  --black: '#030303';
+  --white: '#fcfcfc';
+
+  /* Gray 02, 98 */
+  /*  --black: '#050505'; */
+  /*  --white: '#fafafa'; */
+
+  /* Gray 06, 94 */
+  /*  --black: '#0f0f0f; */
+  /*  --white: '#f4f4f4; */
 }
 
 :root {

--- a/packages/tailwind-config/tailwind.config.js
+++ b/packages/tailwind-config/tailwind.config.js
@@ -118,17 +118,21 @@ const config = ({ useTailwind = true }) => ({
         /**
          * App
          */
-        // black: '#000000', // Black
-        // white: '#ffffff', // White
+        // // Gray 00, 100
+        // black: '#000000',
+        // white: '#ffffff',
 
-        black: '#030303', // Gray 01
-        white: '#fcfcfc', // Gray 99
+        // Gray 01, 99
+        black: '#030303',
+        white: '#fcfcfc',
 
-        // black: '#050505', // Gray 02
-        // white: '#fafafa', // Gray 98
+        // // Gray 02, 98
+        // black: '#050505',
+        // white: '#fafafa',
 
-        // black: '#0f0f0f', // Gray 06
-        // white: '#f4f4f4', // Gray 94
+        // // Gray 06, 94
+        // black: '#0f0f0f',
+        // white: '#f4f4f4',
 
         /**
          * Social
@@ -182,11 +186,11 @@ const config = ({ useTailwind = true }) => ({
           from: { opacity: 0, transform: 'translate(-50%, -48%) scale(0.96)' },
           to: { opacity: 1, transform: 'translate(-50%, -50%) scale(1)' },
         },
+        // navigation-menu
         enterFromLeft: {
           from: { opacity: 0, transform: 'translateX(-200px)' },
           to: { opacity: 1, transform: 'translateX(0)' },
         },
-        // navigation-menu
         enterFromRight: {
           from: { opacity: 0, transform: 'translateX(200px)' },
           to: { opacity: 1, transform: 'translateX(0)' },

--- a/sites/jerandky.com/src/components/Providers/ThemeProvider.client.tsx
+++ b/sites/jerandky.com/src/components/Providers/ThemeProvider.client.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { ThemeProviderProps } from 'next-themes/dist/types'
 import React from 'react'

--- a/sites/jeromefitzgerald.com/src/app/(notion)/books/_components/Book.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/books/_components/Book.client.tsx
@@ -135,7 +135,7 @@ function Books({ data }) {
                     <Card className="h-fit w-full" size="1" variant="surface">
                       <Flex
                         direction={{ initial: 'column', md: 'row-reverse' }}
-                        gap={{ initial: '6', lg: '6' }}
+                        gap={{ initial: '6', md: '6' }}
                         justify="between"
                       >
                         <Inset
@@ -147,7 +147,7 @@ function Books({ data }) {
                                 properties={properties}
                               /> */}
                           <NextImage
-                            className="mx-auto h-auto max-h-[275px] w-full min-w-[175px] max-w-64 lg:h-full lg:max-h-full lg:min-w-[275px] lg:max-w-[575px]"
+                            className="mx-auto h-auto max-h-[275px] w-full min-w-[175px] max-w-64 md:h-full md:max-h-full md:min-w-[275px] md:max-w-[575px]"
                             role="img"
                             tabIndex={-1}
                             {...image}
@@ -166,7 +166,7 @@ function Books({ data }) {
                           <Text
                             as="p"
                             className="line-clamp-3 pb-2"
-                            size={{ initial: '2', lg: '5' }}
+                            size={{ initial: '2', md: '5' }}
                             weight="medium"
                           >
                             {item.author}
@@ -184,7 +184,7 @@ function Books({ data }) {
                           <Text
                             as="p"
                             className="line-clamp-3 pb-2"
-                            size={{ initial: '2', lg: '5' }}
+                            size={{ initial: '2', md: '5' }}
                             weight="medium"
                           >
                             {item.title}
@@ -203,7 +203,7 @@ function Books({ data }) {
                           <Text
                             as="p"
                             className="line-clamp-3 pb-2 font-mono"
-                            size={{ initial: '1', lg: '2' }}
+                            size={{ initial: '1', md: '2' }}
                             weight="medium"
                           >
                             <Code variant="ghost">{item.pages}</Code>
@@ -220,7 +220,7 @@ function Books({ data }) {
                           <Text
                             as="p"
                             className="line-clamp-3 pb-2 font-mono"
-                            size={{ initial: '1', lg: '2' }}
+                            size={{ initial: '1', md: '2' }}
                             weight="medium"
                           >
                             <Code variant="ghost">
@@ -236,11 +236,11 @@ function Books({ data }) {
                           >
                             Status
                           </Text>
-                          <span className="mb-3 mt-2 flex flex-row flex-wrap gap-2 pb-1 font-mono lg:mt-1">
+                          <span className="mb-3 mt-2 flex flex-row flex-wrap gap-2 pb-1 font-mono md:mt-1">
                             <Badge
                               color={book.color}
                               radius="full"
-                              size={{ initial: '1', lg: '1' }}
+                              size={{ initial: '1', md: '1' }}
                             >
                               <>{book.title}</>
                             </Badge>
@@ -269,7 +269,7 @@ function Books({ data }) {
                               highContrast={false}
                               mt="1"
                               radius="full"
-                              size={{ initial: '1', lg: '2' }}
+                              size={{ initial: '1', md: '2' }}
                               variant="outline"
                             >
                               <NextLink href={item.urlBookshop} target="_self">
@@ -287,7 +287,7 @@ function Books({ data }) {
                               highContrast={false}
                               mt="1"
                               radius="full"
-                              size={{ initial: '1', lg: '2' }}
+                              size={{ initial: '1', md: '2' }}
                               variant="outline"
                             >
                               <NextLink href={item.urlBiblio} target="_self">
@@ -343,7 +343,7 @@ function BookPage({ books, title }) {
           </HeadlineTitle>
           <HeadlineTitleSub>
             <></>
-            {/* <Callout className={cx('m-2 w-full p-4 lg:w-11/12')} color="mint">
+            {/* <Callout className={cx('m-2 w-full p-4 md:w-11/12')} color="mint">
               Links to <Strong>Bookshop</Strong> earn a commission.
             </Callout> */}
           </HeadlineTitleSub>
@@ -369,7 +369,7 @@ function BookPage({ books, title }) {
             </Text>
             <Text size="4">Pittsburgh is home to a lot great bookstores!</Text>
             <Box asChild mb="4" pb="2" width="100%">
-              <ul className="list-inside lg:list-disc">
+              <ul className="list-inside md:list-disc">
                 {/* @todo(types) */}
                 {stores.map((store: any, i) => {
                   if (store.url === '') {
@@ -423,13 +423,13 @@ function BookPage({ books, title }) {
           className={cx(
             'col-span-full h-fit md:col-span-3',
             'sticky top-[calc(var(--header-height)_-_6px)] md:top-28',
-            // 'bg-white lg:bg-transparent dark:bg-black',
-            'bg-whiteA-12 dark:bg-blackA-12 lg:bg-transparent dark:lg:bg-transparent',
+            // 'bg-white md:bg-transparent dark:bg-black',
+            'bg-whiteA-12 dark:bg-blackA-12 md:bg-transparent dark:md:bg-transparent',
             'backdrop-blur-sm',
             // 'border-b-1 border-grayA-3',
             // 'drop-shadow-sm dark:shadow-white/5  dark:drop-shadow-lg',
             // 'md:border-none md:drop-shadow-none',
-            'z-40 lg:z-0',
+            'z-40 md:z-0',
           )}
         >
           <div
@@ -442,7 +442,7 @@ function BookPage({ books, title }) {
               <SelectRoot
                 defaultValue={bookStatus ?? 'in-progress'}
                 onValueChange={(value) => handleValueChangeBookStatus(value)}
-                size={{ initial: '3', lg: '3' }}
+                size={{ initial: '3', md: '3' }}
               >
                 <SelectTrigger
                   // @todo(radix) asChild this?
@@ -511,7 +511,7 @@ function BookPage({ books, title }) {
             ref={refContainer}
           >
             <ul>
-              <div className="-mx-2 w-0 lg:-mx-8" ref={targetRef} />
+              <div className="-mx-2 w-0 md:-mx-8" ref={targetRef} />
               <Box
                 asChild
                 className={cx(
@@ -520,7 +520,7 @@ function BookPage({ books, title }) {
                   'justify-items-start',
                   'flex flex-row flex-nowrap',
                   'overflow-x-auto',
-                  'gap-4 lg:gap-16',
+                  'gap-4 md:gap-16',
                   'z-0',
                   'first:gap-0',
                 )}

--- a/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Listing.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Listing.client.tsx
@@ -102,7 +102,7 @@ function AccordionClient({ defaultValue, items }) {
                   >
                     <Text
                       as="span"
-                      className="visible inline lg:invisible lg:hidden"
+                      className="visible inline md:invisible md:hidden"
                       size="1"
                     >
                       {dayOfWeekAbbr?.toUpperCase()}, {month}/{dayOfMonth}
@@ -111,7 +111,7 @@ function AccordionClient({ defaultValue, items }) {
                     </Text>
                     <Text
                       as="span"
-                      className="invisible hidden lg:visible lg:inline"
+                      className="invisible hidden md:visible md:inline"
                       size="2"
                     >
                       {dayOfWeek}, {monthName} {dayOfMonthOrdinal}

--- a/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Slug.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Slug.tsx
@@ -117,10 +117,10 @@ function Ticket({ properties }) {
           width="100%"
           wrap="nowrap"
         >
-          <Code size={{ initial: '2', lg: '3' }} variant="ghost" weight="bold">
+          <Code size={{ initial: '2', md: '3' }} variant="ghost" weight="bold">
             {dayOfWeek}, {monthName} {dayOfMonthOrdinal}
           </Code>
-          <CalendarIcon className="size-4 lg:size-5" />
+          <CalendarIcon className="size-4 md:size-5" />
         </Flex>
         <Flex
           align="center"
@@ -134,7 +134,7 @@ function Ticket({ properties }) {
           <Code variant="ghost" weight="bold">
             {time} {timezone}
           </Code>
-          <ClockIcon className="size-4 lg:size-5" />
+          <ClockIcon className="size-4 md:size-5" />
         </Flex>
         <Flex
           align="start"
@@ -151,7 +151,7 @@ function Ticket({ properties }) {
               <Venue id={venues[0]?.id} />
             </Text>
           </Code>
-          <HomeIcon className="mt-[0.2rem] size-4 lg:mt-[0.125rem] lg:size-5" />
+          <HomeIcon className="mt-[0.2rem] size-4 md:mt-[0.125rem] md:size-5" />
         </Flex>
       </Flex>
       <Flex
@@ -174,7 +174,7 @@ function Ticket({ properties }) {
             <>{disabledText}</>
           </Button>
         )}
-        <TicketIcon className="size-4 lg:size-5" />
+        <TicketIcon className="size-4 md:size-5" />
       </Flex>
     </>
   )
@@ -267,7 +267,7 @@ async function Slug({ revalidate, segmentInfo }) {
         </HeadlineColumnA>
         <HeadlineContent>
           <Callout size="1" variant="outline" />
-          <Heading size={{ initial: '7', lg: '9' }}>{title}</Heading>
+          <Heading size={{ initial: '7', md: '9' }}>{title}</Heading>
           <Image properties={properties} />
           <Blocks data={data?.blocks} />
         </HeadlineContent>

--- a/sites/jeromefitzgerald.com/src/app/(notion)/music/_components/Music.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/music/_components/Music.client.tsx
@@ -131,7 +131,7 @@ function DataItemLoader({ error, handleScroll, isLoadingMore }) {
         <Card className="h-fit w-full" size="1" variant="surface">
           <Flex
             direction={{ initial: 'column', md: 'row-reverse' }}
-            gap={{ initial: '2', lg: '6' }}
+            gap={{ initial: '2', md: '6' }}
           >
             <Inset clip="padding-box" side={{ initial: 'top', md: 'all' }}>
               <Image
@@ -160,7 +160,7 @@ function DataItemLoader({ error, handleScroll, isLoadingMore }) {
               <Text
                 as="p"
                 className="line-clamp-3"
-                size={{ initial: '3', lg: '5' }}
+                size={{ initial: '3', md: '5' }}
                 weight="medium"
               >
                 {isLoadingMore // ? 'loading' : isReachingEnd ? 'no more' :''
@@ -173,7 +173,7 @@ function DataItemLoader({ error, handleScroll, isLoadingMore }) {
                 as="p"
                 className="line-clamp-3"
                 mt="2"
-                size={{ initial: '3', lg: '5' }}
+                size={{ initial: '3', md: '5' }}
                 weight="regular"
               >
                 {isLoadingMore // ? 'loading' : isReachingEnd ? 'no more' :''
@@ -260,15 +260,15 @@ function DataItem({ item, type }) {
         <Card className="h-fit w-full" size="1" variant="surface">
           <Flex
             direction={{ initial: 'column', md: 'row-reverse' }}
-            gap={{ initial: '2', lg: '6' }}
+            gap={{ initial: '2', md: '6' }}
             height="100%"
-            maxWidth={{ initial: '320px', lg: '725px' }}
+            maxWidth={{ initial: '320px', md: '725px' }}
           >
             <Inset clip="padding-box" side={{ initial: 'top', md: 'all' }}>
               <Image
                 {...image}
                 alt={_alt}
-                className="mx-auto h-auto w-full max-w-64 lg:h-full lg:max-w-[575px]"
+                className="mx-auto h-auto w-full max-w-64 md:h-full md:max-w-[575px]"
                 placeholder="blur"
                 role="img"
                 tabIndex={-1}
@@ -287,7 +287,7 @@ function DataItem({ item, type }) {
               <Text
                 as="p"
                 className="line-clamp-3 pb-2"
-                size={{ initial: '2', lg: '5' }}
+                size={{ initial: '2', md: '5' }}
                 weight="medium"
               >
                 {_title1}
@@ -306,7 +306,7 @@ function DataItem({ item, type }) {
                   <Text
                     as="p"
                     className="line-clamp-3 pb-2"
-                    size={{ initial: '2', lg: '5' }}
+                    size={{ initial: '2', md: '5' }}
                     weight="medium"
                   >
                     {_title2}
@@ -324,7 +324,7 @@ function DataItem({ item, type }) {
                   <Text
                     as="p"
                     className="line-clamp-3 pb-2"
-                    size={{ initial: '2', lg: '5' }}
+                    size={{ initial: '2', md: '5' }}
                     weight="medium"
                   >
                     {_title3}
@@ -342,7 +342,7 @@ function DataItem({ item, type }) {
                   <Text
                     as="p"
                     className="line-clamp-3 pb-2 font-mono"
-                    size={{ initial: '1', lg: '2' }}
+                    size={{ initial: '1', md: '2' }}
                     weight="medium"
                   >
                     {item.album.release_date.slice(0, 4)}
@@ -358,26 +358,26 @@ function DataItem({ item, type }) {
               >
                 Genre{genres.length > 1 && 's'}
               </Text>
-              <span className="mb-3 mt-2 flex flex-row flex-wrap gap-2 pb-1 font-mono lg:mt-1">
+              <span className="mb-3 mt-2 flex flex-row flex-wrap gap-2 pb-1 font-mono md:mt-1">
                 {genres.map((genre) => {
                   if (!genre) return null
                   return (
                     <Badge
                       key={`g--${genre}`}
                       radius="full"
-                      size={{ initial: '1', lg: '1' }}
+                      size={{ initial: '1', md: '1' }}
                     >
                       {genre}
                     </Badge>
                   )
                 })}
                 {!!genresExtra && (
-                  <Badge color="gray" radius="full" size={{ initial: '1', lg: '1' }}>
+                  <Badge color="gray" radius="full" size={{ initial: '1', md: '1' }}>
                     {genresExtra}
                   </Badge>
                 )}
                 {genres.length === 0 && (
-                  <Badge color="gray" radius="full" size={{ initial: '1', lg: '1' }}>
+                  <Badge color="gray" radius="full" size={{ initial: '1', md: '1' }}>
                     N/A
                   </Badge>
                 )}
@@ -406,7 +406,7 @@ function DataItem({ item, type }) {
                   highContrast={false}
                   mt="1"
                   radius="full"
-                  size={{ initial: '1', lg: '2' }}
+                  size={{ initial: '1', md: '2' }}
                   variant="outline"
                 >
                   <NextLink href={_href}>
@@ -512,7 +512,7 @@ function DataItems() {
           ref={refContainer}
         >
           <ul>
-            <div className="-mx-2 w-0 lg:-mx-8" ref={targetRef} />
+            <div className="-mx-2 w-0 md:-mx-8" ref={targetRef} />
             <Box
               asChild
               className={cx(
@@ -521,7 +521,7 @@ function DataItems() {
                 'justify-items-start',
                 'flex flex-row flex-nowrap',
                 'overflow-x-auto',
-                'gap-4 lg:gap-16',
+                'gap-4 md:gap-16',
                 'z-0',
                 'first:gap-0',
               )}
@@ -635,7 +635,7 @@ function MusicClient({}) {
               ’s musical guests on Bandcamp:
             </Text>
             <Box asChild mb="4" pb="2" width="100%">
-              <ul className="list-inside lg:list-disc">
+              <ul className="list-inside md:list-disc">
                 {bandcamps.map(({ album, artist: _artist, href }, id) => {
                   const artist = addS(_artist)
                   return (
@@ -666,13 +666,13 @@ function MusicClient({}) {
           className={cx(
             'col-span-full h-fit md:col-span-3',
             'sticky top-[calc(var(--header-height)_-_6px)] md:top-28',
-            // 'bg-white lg:bg-transparent dark:bg-black',
-            'bg-whiteA-12 dark:bg-blackA-12 lg:bg-transparent',
+            // 'bg-white md:bg-transparent dark:bg-black',
+            'bg-whiteA-12 dark:bg-blackA-12 md:bg-transparent',
             'backdrop-blur-sm',
             // 'border-b-1 border-grayA-3',
             // 'drop-shadow-sm dark:shadow-white/5  dark:drop-shadow-lg',
             // 'md:border-none md:drop-shadow-none',
-            'z-40 lg:z-0',
+            'z-40 md:z-0',
           )}
         >
           <div
@@ -685,7 +685,7 @@ function MusicClient({}) {
               <SelectRoot
                 defaultValue={spotifyTimeRange ?? INIT.time_range}
                 onValueChange={(value) => handleValueChangeTimeRange(value)}
-                size={{ initial: '3', lg: '3' }}
+                size={{ initial: '3', md: '3' }}
               >
                 <SelectTrigger
                   // @todo(radix) asChild this?

--- a/sites/jeromefitzgerald.com/src/app/(notion)/podcasts/[[...catchAll]]/_components/Episode.Slug.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/podcasts/[[...catchAll]]/_components/Episode.Slug.tsx
@@ -102,15 +102,15 @@ function Rollups({ properties }) {
         const ComponentProps = isCode ? { variant: 'ghost' } : {}
         return (
           <Box
-            // className="col-span-6 lg:col-span-4"
-            gridColumn={{ initial: 'span 6 / span 6', lg: 'span 4 / span 4' }}
+            // className="col-span-6 md:col-span-4"
+            gridColumn={{ initial: 'span 6 / span 6', md: 'span 4 / span 4' }}
             key={`rollup-${rollup.id}`}
           >
             <Text className="uppercase">
               <Strong>{rollup.id}</Strong>
             </Text>
             <ul>
-              <Box asChild mb={{ initial: '2', lg: '1' }}>
+              <Box asChild mb={{ initial: '2', md: '1' }}>
                 <li>
                   {/* @todo(types) pass types better at Component/Props */}
                   {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}

--- a/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/_components/Show.UpcomingShows.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/shows/[[...catchAll]]/_components/Show.UpcomingShows.tsx
@@ -62,7 +62,7 @@ function UpcomingShows({ properties }) {
   if (itemsCount === 0)
     return (
       <Box asChild display="inline-block">
-        <Text size={{ initial: '4', lg: '7' }}>No Upcoming Shows</Text>
+        <Text size={{ initial: '4', md: '7' }}>No Upcoming Shows</Text>
       </Box>
     )
   return (
@@ -76,8 +76,8 @@ function UpcomingShows({ properties }) {
               const { id } = item
 
               return (
-                <Box asChild my={{ initial: '2', lg: '1' }}>
-                  <li className={cx('my-2 lg:my-0.5')} key={id}>
+                <Box asChild my={{ initial: '2', md: '1' }}>
+                  <li className={cx('my-2 md:my-0.5')} key={id}>
                     {/* @todo(notion) loading component will break, has been reworked */}
                     {/* <Suspense fallback={<RelationLoading />}> */}
                     <Suspense fallback={null}>

--- a/sites/jeromefitzgerald.com/src/app/_temp/Footer.Cmdk.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/_temp/Footer.Cmdk.client.tsx
@@ -1,7 +1,10 @@
 'use client'
 import { useOs } from '@mantine/hooks'
+import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
 import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
 import { Kbd } from '@radix-ui/themes/dist/esm/components/kbd.js'
+import { Skeleton } from '@radix-ui/themes/dist/esm/components/skeleton.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 
 import { useStore as _useStore } from '@/store/index'
 
@@ -12,28 +15,33 @@ const useStore = () => {
   }))
 }
 
-function FooterCmdkClient() {
+function FooterCmdkClient({ isLoading }) {
   const { isCmdkOpenSet } = useStore()
   const os = useOs()
   const isMac = os === 'macos'
   const key = isMac ? '⌘' : 'Ctrl'
   // const button = isMac ? 'Cmd' : 'Ctrl'
   return (
-    <Button
-      className="gap-[0.5rem] group-hover:cursor-pointer lg:flex"
-      highContrast
-      onClick={() => {
-        isCmdkOpenSet()
-      }}
-      radius="medium"
-      size="3"
-      variant="ghost"
-    >
-      <span className="gap-[0.25rem] lg:flex">
-        <Kbd className="font-mono group-hover:cursor-pointer">{key} + K</Kbd>
-      </span>
-      <p className="text-gray-12">Command Menu</p>
-    </Button>
+    <Skeleton loading={isLoading}>
+      <Button
+        className="gap-[0.5rem] font-mono hover:cursor-pointer lg:flex"
+        highContrast
+        onClick={() => {
+          isCmdkOpenSet()
+        }}
+        radius="medium"
+        size="3"
+        variant="ghost"
+      >
+        <Text className="text-gray-12 mr-1" size="2">
+          Command Menu
+        </Text>
+        <Box className="gap-[0.25rem] lg:flex">
+          <Kbd className="group-hover:cursor-pointer">{key}</Kbd>
+          <Kbd className="group-hover:cursor-pointer">K</Kbd>
+        </Box>
+      </Button>
+    </Skeleton>
   )
 }
 

--- a/sites/jeromefitzgerald.com/src/app/_temp/Footer.Theme.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/_temp/Footer.Theme.client.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+'use client'
+import { MoonIcon, SunIcon } from '@jeromefitz/ds/components/Icon/index'
+import { cx } from '@jeromefitz/ds/utils/cx'
+
+// import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import {
+  Item as RadioCardGroupItem,
+  Root as RadioCardGroupRoot,
+} from '@radix-ui/themes/dist/esm/components/radio-card-group.js'
+import { Skeleton } from '@radix-ui/themes/dist/esm/components/skeleton.js'
+import { useTheme } from 'next-themes'
+
+function FooterThemeClient({ isLoading }) {
+  const { setTheme, theme } = useTheme()
+
+  return (
+    // @ts-ignore
+    <RadioCardGroupRoot
+      className={cx(
+        '[--accent-indicator:var(--pink-6)]',
+        '![--grid-template-columns:repeat(2,_minmax(0,_1fr))]',
+      )}
+      defaultValue={theme}
+      gap="1"
+      highContrast={false}
+      size="1"
+    >
+      <Skeleton loading={isLoading}>
+        <RadioCardGroupItem
+          className="hover:cursor-pointer"
+          onClick={() => setTheme('dark')}
+          value="dark"
+        >
+          <MoonIcon />
+        </RadioCardGroupItem>
+      </Skeleton>
+      <Skeleton loading={isLoading}>
+        <RadioCardGroupItem
+          className="hover:cursor-pointer"
+          onClick={() => setTheme('light')}
+          value="light"
+        >
+          <SunIcon />
+        </RadioCardGroupItem>
+      </Skeleton>
+    </RadioCardGroupRoot>
+  )
+}
+
+export { FooterThemeClient }

--- a/sites/jeromefitzgerald.com/src/app/_temp/Footer.Version.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/_temp/Footer.Version.client.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { ArchiveIcon } from '@jeromefitz/ds/components/Icon/index'
+
+import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+import { Skeleton } from '@radix-ui/themes/dist/esm/components/skeleton.js'
+import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
+// eslint-disable-next-line no-restricted-imports
+import NextLink from 'next/link'
+
+/**
+ * @note ignore this file for CI linting (created on next build)
+ */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import buildInfo from '@/config/build-info.json'
+const { isBranchMain, prerelease, version } = buildInfo
+
+function FooterVersionClient({ isLoading }) {
+  return (
+    <Skeleton loading={isLoading}>
+      <Button asChild highContrast radius="medium" size="3" variant="ghost">
+        <NextLink
+          className="gap-2 group-hover:cursor-pointer lg:flex"
+          href={'/colophon'}
+        >
+          <ArchiveIcon className="text-gray-12" />
+          <Text className="text-gray-12 font-mono" size="2">
+            v{isBranchMain ? version : `${version}-${prerelease}`}
+          </Text>
+        </NextLink>
+      </Button>
+    </Skeleton>
+  )
+}
+
+export { FooterVersionClient }

--- a/sites/jeromefitzgerald.com/src/app/_temp/Footer.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/_temp/Footer.client.tsx
@@ -1,31 +1,34 @@
 'use client'
 import { Callout } from '@jeromefitz/ds/components/Callout/index'
 import {
-  ArchiveIcon,
   ExternalLinkIcon,
   InfoCircledIcon,
 } from '@jeromefitz/ds/components/Icon/index'
 import { cx } from '@jeromefitz/ds/utils/cx'
 
+/**
+ * @todo(radix-ui) issue w/ flex.props.js init order
+ *
+ * ref: https://github.com/JeromeFitz/websites/pull/2341
+ */
+import { Flex } from '@radix-ui/themes'
+// import { Avatar } from '@radix-ui/themes/dist/esm/components/avatar.js'
 import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
 import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
+// import { Flex } from '@radix-ui/themes/dist/esm/components/flex.js'
+// import { Grid as GridRadix } from '@radix-ui/themes/dist/esm/components/grid.js'
+import { Separator } from '@radix-ui/themes/dist/esm/components/separator.js'
 import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 import dynamic from 'next/dynamic.js'
-// eslint-disable-next-line no-restricted-imports
-import NextLink from 'next/link'
+import { NotionEmoji as EmojiWrapper } from 'next-notion/blocks/Emoji'
+import { useEffect, useState } from 'react'
 
 import { Grid } from '@/components/Grid/index'
-/**
- * @note ignore this file for CI linting (created on next build)
- */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import buildInfo from '@/config/build-info.json'
 import { socials } from '@/data/socials'
 
 // import { FooterCmdkClient } from './Footer.Cmdk.client'
-
-const { isBranchMain, prerelease, version } = buildInfo
+// import { FooterThemeClient } from './Footer.Theme.client'
+// import { FooterVersionClient } from './Footer.Version.client'
 
 const FooterCmdkClient = dynamic(
   async () => {
@@ -34,139 +37,175 @@ const FooterCmdkClient = dynamic(
   },
   { ssr: true },
 )
+const FooterThemeClient = dynamic(
+  async () => {
+    const { FooterThemeClient: Component } = await import('./Footer.Theme.client')
+    return { default: Component }
+  },
+  { ssr: true },
+)
+const FooterVersionClient = dynamic(
+  async () => {
+    const { FooterVersionClient: Component } = await import(
+      './Footer.Version.client'
+    )
+    return { default: Component }
+  },
+  { ssr: true },
+)
 
 function FooterClient() {
+  const [isLoading, isLoadingSet] = useState(true)
+  useEffect(() => isLoadingSet(false), [isLoading])
   return (
-    <Grid
-      as="div"
-      className={cx(
-        'top-0 z-10 mx-auto w-full ',
-        'col-span-full',
-        'bg-white dark:bg-black',
-        'border-t-1 border-grayA-3',
-        '',
-        'lg:py-12',
-      )}
-    >
-      <div className="col-span-full my-8 flex items-end justify-start">
-        <Callout
-          className={cx('m-2 max-w-screen-sm p-4')}
-          icon={InfoCircledIcon}
-          size="1"
-          variant="surface"
-        >
-          <Box asChild display="block">
-            <Text as="span" size="2">
-              This site is being actively developed.
-            </Text>
-          </Box>
-          <Box asChild display="block">
-            <Text as="span" size="2">
-              So though it is nowhere near perfect, it is shippable, heh.
-            </Text>
-          </Box>
-          <Box asChild display="block">
-            <Text as="span" size="2">
-              Consider this eternally under construction.
-            </Text>
-          </Box>
-        </Callout>
-      </div>
-      <div
+    <>
+      <Separator size="4" />
+      <Grid
+        as="div"
         className={cx(
-          // 'flex items-center justify-start',
-          'flex items-center justify-center lg:items-end lg:justify-start',
-          'col-span-full my-2 py-2',
-          'lg:col-span-4 lg:my-1 lg:mr-4 lg:py-1 lg:pr-4',
+          'top-0 z-10 mx-auto w-full ',
+          'col-span-full',
+          'bg-white dark:bg-black',
+          '',
+          'lg:pb-2 lg:pt-8',
         )}
       >
-        <ul
-          className={cx(
-            'flex flex-row flex-wrap lg:flex-col',
-            'place-items-baseline items-start justify-between',
-          )}
-        >
-          <li>
-            <span className="text-gray-12 tracking-1 mb-2 pb-2 font-bold uppercase">
-              Social
-            </span>
-          </li>
-          {socials.map((social) => {
-            if (!social.active) return null
-
-            return (
-              <li
-                className={cx('my-2 basis-1/2 lg:basis-0')}
-                key={`footer--social--${social.id}`}
-              >
-                <Button
-                  asChild
-                  highContrast
-                  radius="medium"
-                  size="3"
-                  variant="ghost"
-                >
-                  <a
-                    className={cx(
-                      'hover:cursor-pointer lg:flex',
-                      'text-gray-12 hover:text-gray-12',
-                      'duration-250 transition-colors',
-                      'place-content-start items-center justify-items-start lg:w-full',
-                      social.className,
-                    )}
-                    href={social.url}
-                    target="_blank"
-                  >
-                    {social.icon}
-                    <p className="text-inherit">{social.title}</p>{' '}
-                    <ExternalLinkIcon className="text-gray-12" />
-                  </a>
-                </Button>
-              </li>
-            )
-          })}
-        </ul>
-      </div>
-      <div
-        className={cx(
-          'flex items-center justify-end lg:items-end lg:justify-end',
-          'col-span-full my-1 py-1',
-          'lg:col-span-8 lg:my-1 lg:py-1',
-        )}
-      >
-        <div className="flex flex-col items-end justify-start gap-3 py-4 align-text-bottom lg:py-0">
-          <div className={cx('lg:flex lg:items-center', 'gap-2', 'group')}>
-            <Button asChild highContrast radius="medium" size="3" variant="ghost">
-              <NextLink
-                className="gap-2 group-hover:cursor-pointer lg:flex"
-                href={'/colophon'}
-              >
-                <ArchiveIcon className="text-gray-12" />
-                <p className="text-gray-12 font-mono">
-                  v{isBranchMain ? version : `${version}-${prerelease}`}
-                </p>
-              </NextLink>
-            </Button>
-          </div>
-          <div
-            className={cx(
-              'hidden font-mono lg:flex lg:items-center',
-              'gap-2',
-              'group',
-            )}
+        <div className="col-span-full flex items-end justify-start">
+          <Callout
+            className={cx('m-0 max-w-screen-sm p-4 md:m-0')}
+            icon={InfoCircledIcon}
+            size="2"
+            variant="surface"
           >
-            <FooterCmdkClient />
-          </div>
-          <div className="font-mono">
-            <span className="mr-2 size-4">©</span>
-            <span>
-              <span>Nice Group of People, LLC –&nbsp;</span>
-              <span>{new Date().getFullYear()}</span>
-            </span>
-          </div>
+            <Box asChild display="block">
+              <Text as="span" size="2">
+                This site is nowhere near perfect, but it is shippable, heh.
+              </Text>
+            </Box>
+            <Box asChild display="block">
+              <Text as="span" size="2">
+                Consider this eternally under construction.
+              </Text>
+            </Box>
+          </Callout>
         </div>
-      </div>
-    </Grid>
+      </Grid>
+      <Grid
+        as="div"
+        className={cx(
+          'top-0 z-10 mx-auto w-full md:min-h-[225px]',
+          'col-span-full',
+          '',
+          'lg:py-12',
+        )}
+      >
+        <Flex
+          className="col-span-full"
+          direction={{ initial: 'column-reverse', md: 'row' }}
+          gap={{ initial: '6', md: '0' }}
+          justify="between"
+          width="100%"
+        >
+          <Flex
+            align={{ initial: 'center', md: 'end' }}
+            className="col-span-full  md:col-span-5"
+            gap="2"
+            justify="start"
+          >
+            {/* <Avatar
+              fallback="J"
+              radius="full"
+              // @ts-ignore
+              src="/images/favicon/apple-touch-icon.png"
+              variant="soft"
+            /> */}
+            <Flex
+              direction={{ initial: 'column', md: 'column' }}
+              gap={{ initial: '6', md: '4' }}
+              width="100%"
+            >
+              <ul
+                className={cx(
+                  'flex flex-row gap-4',
+                  'justify-center',
+                  'md:place-items-baseline md:items-center md:justify-start',
+                )}
+              >
+                {socials.map((social) => {
+                  if (!social.active) return null
+
+                  return (
+                    <li className={cx('')} key={`footer--social--${social.id}`}>
+                      <Button
+                        asChild
+                        highContrast
+                        radius="full"
+                        size="2"
+                        variant="ghost"
+                      >
+                        <a
+                          className={cx(
+                            'hover:cursor-pointer lg:flex',
+                            'text-gray-12 hover:text-gray-12',
+                            // 'duration-250 transition-colors',
+                            'place-content-start items-center justify-items-start lg:w-full',
+                            social.className,
+                          )}
+                          href={social.url}
+                          target="_blank"
+                        >
+                          {social.icon}
+                          <span
+                            className={cx(
+                              // 'flex flex-row items-center justify-center gap-2',
+                              'hidden',
+                              '',
+                            )}
+                          >
+                            <span className="text-inherit">{social.title}</span>{' '}
+                            <ExternalLinkIcon className="text-gray-12" />
+                          </span>
+                        </a>
+                      </Button>
+                    </li>
+                  )
+                })}
+              </ul>
+              <Text
+                align={{ initial: 'center', md: 'left' }}
+                className="font-mono"
+                size={{ initial: '1', md: '2' }}
+              >
+                <Text className="mr-0 size-4 font-sans md:mr-2">
+                  <EmojiWrapper id={`no-need-2`} text={`©`} />
+                </Text>
+                <Box as="span" display="inline">
+                  <Text>Nice Group of People, LLC –&nbsp;</Text>
+                  <Text className="">{new Date().getFullYear()}</Text>
+                </Box>
+              </Text>
+            </Flex>
+          </Flex>
+          <Flex
+            align={{ initial: 'center', md: 'end' }}
+            className="col-span-full md:col-span-7"
+            direction={{ initial: 'row', md: 'column' }}
+            gap="4"
+            justify={{ initial: 'between', md: 'end' }}
+          >
+            <Box className="min-h-9">
+              <FooterThemeClient isLoading={isLoading} />
+            </Box>
+            <Box className="mr-2 min-h-9 md:mr-0 md:min-h-6">
+              <FooterVersionClient isLoading={isLoading} />
+            </Box>
+            <Box className="hidden md:inline-flex md:min-h-6">
+              <FooterCmdkClient isLoading={isLoading} />
+            </Box>
+          </Flex>
+        </Flex>
+      </Grid>
+    </>
   )
 }
 

--- a/sites/jeromefitzgerald.com/src/app/_temp/Footer.tsx
+++ b/sites/jeromefitzgerald.com/src/app/_temp/Footer.tsx
@@ -8,12 +8,16 @@
  *  while in layout.tsx
  *
  */
+import { memo } from 'react'
+
 import { FooterClient } from './Footer.client'
+
+const FooterClientMemoized = memo(FooterClient)
 
 function Footer() {
   return (
     <>
-      <FooterClient />
+      <FooterClientMemoized />
     </>
   )
 }

--- a/sites/jeromefitzgerald.com/src/app/layout.tsx
+++ b/sites/jeromefitzgerald.com/src/app/layout.tsx
@@ -105,7 +105,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       >
         <body
           className={cx(
-            'overflow-y-auto overflow-x-hidden lg:overflow-y-auto',
+            'overflow-y-auto overflow-x-hidden md:overflow-y-auto',
             'selection:bg-gray-12 selection:text-gray-1',
             'bg-white dark:bg-black',
             'font-sans antialiased',

--- a/sites/jeromefitzgerald.com/src/app/playground/2024/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/2024/page.tsx
@@ -15,7 +15,7 @@ function SectionContainer() {
       <div
         className={cx(
           'inset-y-0 z-50 flex w-full flex-col items-center',
-          'pt-10 lg:pt-0',
+          'pt-10 md:pt-0',
           'mx-auto max-w-screen-xl',
         )}
       >

--- a/sites/jeromefitzgerald.com/src/components/Accordion/AccordionListItem.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Accordion/AccordionListItem.tsx
@@ -7,8 +7,8 @@ import NextLink from 'next/link'
 
 // const useStoreMenu = () => {
 //   return useStore((store) => ({
-//     isMenuOpen: store.isMenuOpen,
-//     isMenuOpenSet: store.isMenuOpenSet,
+//     isMenuMobileOpen: store.isMenuMobileOpen,
+//     isMenuMobileOpenSet: store.isMenuMobileOpenSet,
 //   }))
 // }
 
@@ -28,13 +28,13 @@ function AccordionListItem({ children, href, icon, ...props }) {
           'flex w-full select-none flex-row items-center justify-start',
           'transition-colors',
           'my-1 gap-2 py-1',
-          'lg:my-1 lg:gap-3 lg:py-2',
+          'md:my-1 md:gap-3 md:py-2',
           'hover:text-gray-12 hover:bg-gray-4 rounded',
         )}
       >
         <Icon
           aria-hidden
-          className={cx('ml-1 size-4 min-w-4 text-[currentColor] lg:ml-2')}
+          className={cx('ml-1 size-4 min-w-4 text-[currentColor] md:ml-2')}
           label={''}
         />
         <span className="truncate">{children}</span>

--- a/sites/jeromefitzgerald.com/src/components/Banner/Banner.client.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Banner/Banner.client.tsx
@@ -56,7 +56,7 @@ function BannerMobile({ data }) {
       data-radius="full"
       display={{
         initial: 'flex',
-        lg: 'none',
+        md: 'none',
       }}
       gridColumn="1/-1"
       justify="center"
@@ -114,7 +114,7 @@ function BannerDesktop({ data }) {
     <Flex
       align="center"
       direction="row"
-      display={{ initial: 'none', lg: 'flex' }}
+      display={{ initial: 'none', md: 'flex' }}
       gap="1"
       gridColumn="1/-1"
       justify="center"
@@ -187,7 +187,7 @@ function BannerClient() {
     <Flex
       align="center"
       direction="row"
-      display={{ initial: 'flex', lg: 'flex' }}
+      display={{ initial: 'flex', md: 'flex' }}
       gap="1"
       gridColumn="1/-1"
       justify="center"

--- a/sites/jeromefitzgerald.com/src/components/Cmdk/Cmdk.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Cmdk/Cmdk.tsx
@@ -378,7 +378,8 @@ function Cmdk() {
       <Box
         aria-hidden={true}
         className={cx(
-          'duration-250 fixed left-0 top-0 z-50 size-full transition-all',
+          'duration-250 fixed left-0 top-0 z-50 size-full',
+          'transition-all',
           'pointer-events-none',
           isCmdkOpen && isCmdkInnerOpen
             ? 'bg-grayA-2 backdrop-blur-sm'

--- a/sites/jeromefitzgerald.com/src/components/Grid/Grid.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Grid/Grid.tsx
@@ -40,7 +40,7 @@ type GridImpl = GridProps & AdditionalProps
 //       gap="2"
 //       mb="1"
 //       mr="1"
-//       p={{ initial: '4', lg: '8' }}
+//       p={{ initial: '4', md: '8' }}
 //       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //       // @ts-ignore
 //       ref={forwardedRef}
@@ -69,7 +69,7 @@ const GridImpl = forwardRef(function GridImpl(
       )}
       mb="1"
       mr="1"
-      p={{ initial: '4', lg: '8' }}
+      p={{ initial: '4', md: '8' }}
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       ref={forwardedRef}

--- a/sites/jeromefitzgerald.com/src/components/Headline/Headline.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Headline/Headline.tsx
@@ -24,19 +24,19 @@ function HeadlineColumnA({ children, separateTitle = true }: HeadlineColumnAProp
   return (
     <Box
       className={cx(
-        'col-span-full lg:col-span-3',
+        'col-span-full md:col-span-3',
         'flex flex-col justify-start',
         'h-fit',
-        'lg:h-44 lg:max-h-56 lg:min-h-44',
-        'lg:sticky lg:top-28',
+        'md:h-44 md:max-h-56 md:min-h-44',
+        'md:sticky md:top-28',
         '',
       )}
     >
-      <Box className={cx('h-[inherit]', 'lg:h-full lg:max-h-56 lg:min-h-44')}>
+      <Box className={cx('h-[inherit]', 'md:h-full md:max-h-56 md:min-h-44')}>
         <Flex
           className={cx('h-[inherit]', separateTitle && 'justify-between')}
           direction="column"
-          gap={{ initial: '4', lg: '0' }}
+          gap={{ initial: '4', md: '0' }}
           height="inherit"
         >
           {children}
@@ -78,7 +78,7 @@ function HeadlineTitleText({
 type HeadlineTitleSubProps = AdditionalProps
 function HeadlineTitleSub({ children, className }: HeadlineTitleSubProps) {
   return (
-    <div className={cx('flex flex-row flex-wrap gap-2', 'lg:mr-3', className)}>
+    <div className={cx('flex flex-row flex-wrap gap-2', 'md:mr-3', className)}>
       {children}
     </div>
   )
@@ -89,13 +89,13 @@ function HeadlineContent({ children, className = '' }: HeadlineContentProps) {
     <Flex
       className={cx(
         // 'flex flex-col gap-4',
-        'col-span-full lg:col-span-9',
-        // 'mt-4 lg:mt-0',
+        'col-span-full md:col-span-9',
+        // 'mt-4 md:mt-0',
         className,
       )}
       direction="column"
       gap="4"
-      mt={{ initial: '4', lg: '0' }}
+      mt={{ initial: '4', md: '0' }}
     >
       {children}
     </Flex>

--- a/sites/jeromefitzgerald.com/src/components/Navigation/Navigation.desktop.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Navigation/Navigation.desktop.tsx
@@ -1,199 +1,47 @@
 'use client'
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { CaretDownIcon, Pencil2Icon } from '@jeromefitz/ds/components/Icon/index'
+import { CaretDownIcon } from '@jeromefitz/ds/components/Icon/index'
 import { cx } from '@jeromefitz/ds/utils/cx'
 
 import {
-  NavigationMenuContent,
-  NavigationMenuIndicator,
-  NavigationMenuItem,
-  NavigationMenuLink,
-  NavigationMenuList,
+  Content as NavigationMenuContent,
+  Indicator as NavigationMenuIndicator,
+  Item as NavigationMenuItem,
+  Link as NavigationMenuLink,
+  List as NavigationMenuList,
   Root as NavigationMenuRoot,
-  NavigationMenuTrigger,
-  NavigationMenuViewport,
+  Trigger as NavigationMenuTrigger,
+  Viewport as NavigationMenuViewport,
 } from '@radix-ui/react-navigation-menu'
+// import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
 import { Button } from '@radix-ui/themes/dist/esm/components/button.js'
 import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 // eslint-disable-next-line no-restricted-imports
 import NextLink from 'next/link'
-import { Fragment, forwardRef, memo } from 'react'
+import { Fragment, memo } from 'react'
 
 import { menus } from '@/data/menu'
 
-const IS_ICON_SHOWN = false
+// const IS_ICON_SHOWN = false
 
-const NavigationMenu = () => {
+function ListItem({ children, className, href, title, ...props }) {
   return (
-    <div className="col-span-full hidden lg:flex lg:items-center lg:justify-between">
-      {/* @note(navigation) left */}
-      <div className={cx('')}>
-        <div
-          className={cx(
-            'flex shrink grow basis-0 items-center justify-center bg-transparent',
-          )}
-        >
-          {/* @ts-ignore */}
-          <NavigationMenuRoot
-            aria-label="Navigation header with 3 dropdown menus with links and 1 link"
-            className={cx('relative flex w-full items-center justify-center')}
-          >
-            {/* @todo(menu) motion background */}
-            {/* @ts-ignore */}
-            <NavigationMenuList
-              className={cx('m-0 flex list-none justify-center p-0')}
-            >
-              {menus.map((menu) => {
-                if (!menu.isActive) return null
-                const Icon = menu.icon
-                return (
-                  // @ts-ignore
-                  <NavigationMenuItem
-                    className={cx(
-                      'cursor-pointer select-none transition-colors',
-                      'hocus:hover:text-accent-11',
-                      'first-of-type:relative first-of-type:-left-4',
-                    )}
-                    key={`nav--${menu.id}`}
-                  >
-                    {menu.isParent ? (
-                      <Fragment key={`nav--${menu.id}--p`}>
-                        {/* @ts-ignore */}
-                        <NavigationMenuTrigger
-                          className={cx(
-                            'group flex items-center justify-center',
-                            'rounded-item hover:bg-grayA-2',
-                            'px-3 py-2',
-                            'transition-colors',
-                          )}
-                        >
-                          <Button
-                            asChild
-                            className={cx()}
-                            radius="full"
-                            size="1"
-                            variant="ghost"
-                          >
-                            <>
-                              {menu.title}
-                              {` `}
-                              <CaretDownIcon
-                                aria-hidden
-                                className={cx(
-                                  'duration-250 group-data-[state=open]:text-accent-11 text-accent-12 relative top-[1px] mr-1 transition-transform ease-in group-data-[state=open]:-rotate-180',
-                                )}
-                                label={''}
-                              />
-                            </>
-                          </Button>
-                        </NavigationMenuTrigger>
-                        <NavigationMenuContent className="!absolute left-0 top-0 w-full duration-75 ease-in sm:w-auto">
-                          <ul
-                            className={cx(
-                              'mx-4 my-2 flex list-none flex-col p-0',
-                              'w-[586px]',
-                            )}
-                          >
-                            <li
-                              className={cx(
-                                'grid [grid-template-columns:1fr_1fr]',
-                                'gap-3 p-1 outline-none',
-                              )}
-                            >
-                              {menu.items.map((item) => {
-                                if (!item.isActive) return null
-                                return (
-                                  // @ts-ignore
-                                  <ListItem
-                                    href={item.href}
-                                    key={`nav--${menu.id}--p--${item.id}`}
-                                    title={item.title}
-                                  >
-                                    {item.titleDescription}
-                                  </ListItem>
-                                )
-                              })}
-                            </li>
-                          </ul>
-                        </NavigationMenuContent>
-                      </Fragment>
-                    ) : (
-                      <NextLink href={menu.href} legacyBehavior passHref>
-                        <Text
-                          asChild
-                          className={cx(
-                            'group flex',
-                            // 'place-items-center items-center justify-center',
-                            'hover:bg-grayA-2 rounded-item',
-                            'px-3 py-2',
-                            'transition-colors',
-                          )}
-                        >
-                          <NavigationMenuLink>
-                            {menu.isParentIconVisible ? (
-                              <>
-                                <Icon className="hocus:hover:text-accent-11  mt-1 transition-colors" />
-                                <span className="hidden">{menu.title}</span>
-                              </>
-                            ) : (
-                              menu.title
-                            )}
-                          </NavigationMenuLink>
-                        </Text>
-                      </NextLink>
-                    )}
-                  </NavigationMenuItem>
-                )
-              })}
-
-              {/* @ts-ignore */}
-              <NavigationMenuIndicator className="data-[state=visible]:animate-fadeIn data-[state=hidden]:animate-fadeOut top-full z-[1] flex h-[10px] items-end justify-center overflow-hidden transition-[width,transform_250ms_ease]">
-                <div className="bg-accentA-6 dark:bg-accentA-12 relative top-[70%] size-[10px] rotate-[45deg] rounded-tl-[2px]" />
-              </NavigationMenuIndicator>
-            </NavigationMenuList>
-
-            <div className="perspective-[2000px] absolute left-0 top-full flex w-full justify-start">
-              <NavigationMenuViewport
-                // @ts-ignore
-                className={cx(
-                  'absolute',
-                  'data-[state=open]:animate-scaleIn data-[state=closed]:animate-scaleOut   shadow-6 rounded-1 mt-[10px] h-[var(--radix-navigation-menu-viewport-height)] w-full origin-[top_center] overflow-hidden border-2 transition-[width,_height] duration-300 sm:w-[var(--radix-navigation-menu-viewport-width)]',
-                  'bg-white dark:bg-black',
-                  'border-accentA-6 dark:border-accentA-12',
-                )}
-              />
-            </div>
-          </NavigationMenuRoot>
-        </div>
-      </div>
-      {/* @note(navigation) right */}
-      <div className={cx('')}></div>
-    </div>
-  )
-}
-
-const ListItem = forwardRef(
-  // @ts-ignore
-  ({ children, className, title, ...props }, forwardedRef) => (
-    <NextLink
+    <NavigationMenuLink
+      asChild
+      className={cx(
+        'group',
+        'flex select-none flex-row items-center gap-3 p-3',
+        'text-black dark:text-white',
+        // 'hover:bg-grayA-4',
+        'hover:bg-gray-4',
+        'rounded-3 px-3 py-2',
+        className,
+      )}
       {...props}
-      legacyBehavior
-      passHref
-      // @ts-ignore
-      ref={forwardedRef}
     >
-      <NavigationMenuLink
-        className={cx(
-          'group',
-          'flex select-none flex-row items-center gap-3 p-3',
-          'text-black dark:text-white',
-          'hover:bg-grayA-4',
-          'rounded-3 px-3 py-2',
-          className,
-        )}
-      >
+      <NextLink href={href}>
         <>
-          <div className={cx('items-center justify-start', 'mt-2 h-full', '')}>
+          {/* <div className={cx('items-center justify-start', 'mt-2 h-full', '')}>
             <Pencil2Icon
               aria-hidden
               className={cx(
@@ -202,7 +50,7 @@ const ListItem = forwardRef(
               )}
               label={''}
             />
-          </div>
+          </div> */}
           <div
             className={cx(
               'flex flex-col items-start justify-start',
@@ -223,10 +71,196 @@ const ListItem = forwardRef(
             </Text>
           </div>
         </>
-      </NavigationMenuLink>
+      </NextLink>
+    </NavigationMenuLink>
+  )
+}
+
+function ListRootLink({ menu }) {
+  const Icon = menu.icon
+  return (
+    <NextLink href={menu.href} legacyBehavior passHref>
+      <Text
+        asChild
+        className={cx(
+          'group flex',
+          'rounded-item',
+          // 'hover:bg-grayA-4',
+          'hover:bg-gray-4',
+          'px-3 py-2',
+          'transition-colors',
+          'text-gray-11',
+          'hover:text-gray-12',
+        )}
+      >
+        <NavigationMenuLink>
+          {menu.isParentIconVisible ? (
+            <>
+              <Icon className="hocus:hover:text-accent-11  mt-1 transition-colors" />
+              <span className="hidden">{menu.title}</span>
+            </>
+          ) : (
+            menu.title
+          )}
+        </NavigationMenuLink>
+      </Text>
     </NextLink>
-  ),
-)
+  )
+}
+const ListRootLinkMemoized = memo(ListRootLink)
+
+function ListParent({ menu }) {
+  return (
+    <Fragment key={`nav--${menu.id}--p`}>
+      {/* @ts-ignore */}
+      <NavigationMenuTrigger
+        className={cx(
+          'group flex items-center justify-center',
+          'rounded-item',
+          'px-3 py-2',
+          'transition-colors',
+          'text-gray-11',
+          'data-[state=open]:text-gray-12',
+          // 'data-[state=open]:bg-grayA-4',
+          'data-[state=open]:bg-gray-4',
+        )}
+      >
+        <Button asChild className={cx()} radius="full" size="1" variant="ghost">
+          <>
+            {menu.title}
+            {` `}
+            <CaretDownIcon
+              aria-hidden
+              className={cx(
+                'duration-250 group-data-[state=open]:text-accent-11 text-accent-12 relative top-[1px] mr-1 transition-transform ease-in group-data-[state=open]:-rotate-180',
+              )}
+              label={''}
+            />
+          </>
+        </Button>
+      </NavigationMenuTrigger>
+      <NavigationMenuContent
+        className={cx(
+          'duration-250 absolute left-0 top-0 ease-in-out',
+          'data-[motion=from-start]:animate-enterFromLeft',
+          'data-[motion=from-end]:animate-enterFromRight',
+          'data-[motion=to-start]:animate-exitToLeft',
+          'data-[motion=to-end]:animate-exitToRight',
+          'origin-[top_center] border-2',
+          'shadow-5 rounded-3',
+          // 'bg-whiteA-12 dark:bg-blackA-12',
+          'bg-white dark:bg-black',
+          // 'border-accentA-6 dark:border-accentA-12',
+          'border-accent-6 dark:border-accent-12',
+          'overflow-hidden',
+        )}
+      >
+        <ul className={cx('mx-4 my-2 flex list-none flex-col p-0', 'min-w-[586px]')}>
+          <li
+            className={cx(
+              'grid [grid-template-columns:1fr_1fr]',
+              'gap-3 p-1 outline-none',
+            )}
+          >
+            {menu.items.map((item) => {
+              if (!item.isActive) return null
+              return (
+                // @ts-ignore
+                <ListItem
+                  href={item.href}
+                  key={`nav--${menu.id}--p--${item.id}`}
+                  title={item.title}
+                >
+                  {item.titleDescription}
+                </ListItem>
+              )
+            })}
+          </li>
+        </ul>
+      </NavigationMenuContent>
+    </Fragment>
+  )
+}
+const ListParentMemoized = memo(ListParent)
+
+const NavigationMenu = () => {
+  return (
+    <div className="col-span-full hidden md:flex md:items-center md:justify-between">
+      {/* @note(navigation) left */}
+      <div className={cx('')}>
+        <div
+          className={cx(
+            'flex shrink grow basis-0 items-center justify-center bg-transparent',
+          )}
+        >
+          {/* @ts-ignore */}
+          <NavigationMenuRoot
+            aria-label="Navigation header with 3 dropdown menus with links and 1 link"
+            className={cx('relative flex w-full items-center justify-center')}
+          >
+            {/* @todo(menu) motion background */}
+            {/* @ts-ignore */}
+            <NavigationMenuList
+              className={cx('m-0 flex list-none justify-center p-0')}
+            >
+              {menus.map((menu) => {
+                if (!menu.isActive) return null
+                return (
+                  // @ts-ignore
+                  <NavigationMenuItem
+                    className={cx(
+                      'cursor-pointer select-none transition-colors',
+                      // 'hocus:hover:text-accent-11',
+                      'first-of-type:relative first-of-type:-left-4',
+                    )}
+                    key={`nav--${menu.id}`}
+                  >
+                    {menu.isParent ? (
+                      <ListParentMemoized key={`nav--${menu.id}--p`} menu={menu} />
+                    ) : (
+                      <ListRootLinkMemoized key={`nav--${menu.id}--p`} menu={menu} />
+                    )}
+                  </NavigationMenuItem>
+                )
+              })}
+
+              {/* @ts-ignore */}
+              <NavigationMenuIndicator
+                className={cx(
+                  'data-[state=visible]:animate-fadeIn data-[state=hidden]:animate-fadeOut top-[38px] z-[-1] flex h-[10px] items-end justify-center overflow-hidden ',
+                  // 'transition-[width,transform,_50ms_ease]',
+                  // 'transition-[width,transform] duration-250',
+                  'transition-[width,transform] !duration-0',
+                )}
+              >
+                <div
+                  className={cx(
+                    'relative top-[70%] size-[10px] rotate-[45deg] rounded-tl-[2px]',
+                    // 'bg-accentA-6 dark:bg-accentA-12',
+                    'bg-accent-6 dark:bg-accent-12',
+                  )}
+                />
+              </NavigationMenuIndicator>
+            </NavigationMenuList>
+            <div className="perspective-[2000px] absolute left-0 top-[48px] flex w-full justify-start">
+              <NavigationMenuViewport
+                // @ts-ignore
+                className={cx(
+                  'absolute',
+                  'w-[var(--radix-navigation-menu-viewport-width)]',
+                  'h-[var(--radix-navigation-menu-viewport-height)]',
+                  'duration-250 transition-[width,height] ease-in-out',
+                )}
+              />
+            </div>
+          </NavigationMenuRoot>
+        </div>
+      </div>
+      {/* @note(navigation) right */}
+      <div className={cx('')}></div>
+    </div>
+  )
+}
 
 const NavigationMenuMemo = memo(function _NavigationMenuMemo() {
   return <NavigationMenu />

--- a/sites/jeromefitzgerald.com/src/components/Navigation/Navigation.mobile.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Navigation/Navigation.mobile.tsx
@@ -28,20 +28,20 @@ import { useStore } from '@/store/index'
 
 const useStoreMenu = () => {
   return useStore((store) => ({
-    isMenuOpen: store.isMenuOpen,
-    isMenuOpenSet: store.isMenuOpenSet,
+    isMenuMobileOpen: store.isMenuMobileOpen,
+    isMenuMobileOpenSet: store.isMenuMobileOpenSet,
   }))
 }
 
 const AccordionNavigation = () => {
-  const { isMenuOpen, isMenuOpenSet } = useStoreMenu()
+  const { isMenuMobileOpen, isMenuMobileOpenSet } = useStoreMenu()
   const handleOnClick = () => {
-    if (!isMenuOpen) {
+    if (!isMenuMobileOpen) {
       document.body.classList.add('!overflow-hidden')
     } else {
       document.body.classList.remove('!overflow-hidden')
     }
-    isMenuOpenSet()
+    isMenuMobileOpenSet()
   }
 
   return (
@@ -88,31 +88,31 @@ const AccordionNavigation = () => {
 
 function NavigationMobile() {
   const { setTheme, theme } = useTheme()
-  const { isMenuOpen, isMenuOpenSet } = useStoreMenu()
+  const { isMenuMobileOpen, isMenuMobileOpenSet } = useStoreMenu()
   const handleOnClick = () => {
-    if (!isMenuOpen) {
+    if (!isMenuMobileOpen) {
       document.body.classList.add('!overflow-hidden')
     } else {
       document.body.classList.remove('!overflow-hidden')
     }
-    isMenuOpenSet()
+    isMenuMobileOpenSet()
   }
   return (
     <>
       <Button
         className={cx(
-          'col-span-full flex cursor-pointer items-center justify-end gap-2 lg:hidden',
+          'col-span-full flex cursor-pointer items-center justify-end gap-2 md:hidden',
         )}
         color="pink"
         onClick={handleOnClick}
         size="2"
         variant="ghost"
       >
-        <span>{isMenuOpen ? `Close` : `Open`} Menu</span>
-        {isMenuOpen ? <Cross1Icon /> : <HamburgerMenuIcon />}
+        <span>{isMenuMobileOpen ? `Close` : `Open`} Menu</span>
+        {isMenuMobileOpen ? <Cross1Icon /> : <HamburgerMenuIcon />}
       </Button>
 
-      {isMenuOpen && (
+      {isMenuMobileOpen && (
         // @todo(radix) children
         // @ts-ignore
         <PortalRoot>
@@ -145,7 +145,9 @@ function NavigationMobile() {
                 >
                   <li
                     className={cx(
-                      'flex w-full cursor-pointer select-none items-center transition-colors',
+                      'flex w-full cursor-pointer select-none items-center',
+                      // 'transition-colors',
+                      '',
                     )}
                   >
                     <Button
@@ -171,7 +173,7 @@ function NavigationMobile() {
           >
             <Button
               className={cx(
-                'col-span-full flex cursor-pointer items-center justify-end gap-2 px-7 lg:hidden',
+                'col-span-full flex cursor-pointer items-center justify-end gap-2 px-7 md:hidden',
               )}
               color="pink"
               onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}

--- a/sites/jeromefitzgerald.com/src/components/Navigation/Navigation.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Navigation/Navigation.tsx
@@ -10,16 +10,16 @@ function Navigation() {
     <Grid
       as="div"
       className={cx(
-        'top-0 z-10 mx-auto w-full lg:sticky ',
+        'top-0 z-10 mx-auto w-full md:sticky ',
         'col-span-full',
         'bg-white dark:bg-black',
-        'lg:bg-whiteA-12 lg:dark:bg-blackA-11',
-        'lg:backdrop-blur-sm',
-        'lg:border-b-1 lg:border-grayA-3',
-        'lg:drop-shadow-sm',
-        'lg:dark:shadow-white/5  lg:dark:drop-shadow-lg',
+        'md:bg-whiteA-12 md:dark:bg-blackA-11',
+        'md:backdrop-blur-sm',
+        'md:border-b-1 md:border-grayA-3',
+        'md:drop-shadow-sm',
+        'md:dark:shadow-white/5  md:dark:drop-shadow-lg',
         '',
-        'lg:py-2',
+        'md:py-2',
       )}
     >
       <NavigationDesktop />

--- a/sites/jeromefitzgerald.com/src/components/Notion/Notion.Config.ts
+++ b/sites/jeromefitzgerald.com/src/components/Notion/Notion.Config.ts
@@ -65,28 +65,28 @@ const blocks = {
   },
   callout: {
     className:
-      'border-l-gray-11 bg-grayA-5 m-4 rounded border-l-8 p-14 text-xl lg:text-3xl 2xl:max-w-7xl',
+      'border-l-gray-11 bg-grayA-5 m-4 rounded border-l-8 p-14 text-xl md:text-3xl 2xl:max-w-7xl',
   },
   column: {
-    className: 'my-3 flex flex-[1_1] flex-col lg:my-3 lg:pr-5 ',
+    className: 'my-3 flex flex-[1_1] flex-col md:my-3 md:pr-5 ',
   },
   column_list: {
-    className: 'my-4 flex flex-col justify-between lg:flex-row 2xl:max-w-7xl',
+    className: 'my-4 flex flex-col justify-between md:flex-row 2xl:max-w-7xl',
   },
   divider: {
     className: 'my-7 h-7 w-full',
   },
   heading_1: {
     as: 'h2',
-    className: 'mb-4 text-3xl font-black lg:mb-5 lg:text-4xl font-sans',
+    className: 'mb-4 text-3xl font-black md:mb-5 md:text-4xl font-sans',
   },
   heading_2: {
     as: 'h3',
-    className: 'mb-3 text-2xl font-black lg:mb-4 lg:text-3xl font-sans',
+    className: 'mb-3 text-2xl font-black md:mb-4 md:text-3xl font-sans',
   },
   heading_3: {
     as: 'h3',
-    className: 'mb-2 text-xl font-black lg:mb-3 lg:text-2xl font-sans',
+    className: 'mb-2 text-xl font-black md:mb-3 md:text-2xl font-sans',
   },
   numbered_list: {
     className:
@@ -101,7 +101,7 @@ const blocks = {
   },
   quote: {
     className:
-      'border-l-accent-11 bg-accent-5 m-4 rounded border-l-8 p-6 text-xl lg:p-14 lg:text-3xl font-sans 2xl:max-w-7xl',
+      'border-l-accent-11 bg-accent-5 m-4 rounded border-l-8 p-6 text-xl md:p-14 md:text-3xl font-sans 2xl:max-w-7xl',
   },
   ...custom,
 }

--- a/sites/jeromefitzgerald.com/src/components/Orientation/Orientation.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Orientation/Orientation.tsx
@@ -10,7 +10,7 @@ const isActive = false
 function OrientationContent({ os }) {
   return (
     <>
-      <div className="m-12 flex flex-row items-start justify-start gap-1 py-4 align-text-bottom font-mono lg:py-0">
+      <div className="m-12 flex flex-row items-start justify-start gap-1 py-4 align-text-bottom font-mono md:py-0">
         <span className="mr-2 mt-1 size-4">
           <FileTextIcon className="text-inherit" />
         </span>
@@ -23,7 +23,7 @@ function OrientationContent({ os }) {
           </span>
         </span>
       </div>
-      <div className="m-12 flex flex-row items-start justify-start gap-1 py-4 align-text-bottom font-mono lg:py-0">
+      <div className="m-12 flex flex-row items-start justify-start gap-1 py-4 align-text-bottom font-mono md:py-0">
         <span className="mr-2 mt-1 size-4">
           <UpdateIcon className="text-inherit" />
         </span>

--- a/sites/jeromefitzgerald.com/src/components/Providers/Providers.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Providers/Providers.tsx
@@ -54,13 +54,7 @@ function Providers({ children }) {
   return (
     <>
       <ErrorBoundary>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          disableTransitionOnChange={false}
-          enableSystem
-          value={{ dark: 'dark', light: 'light' }}
-        >
+        <ThemeProvider>
           <StoreProvider>
             <RouterEventProvider />
             <ReactWrapBalancerProvider>

--- a/sites/jeromefitzgerald.com/src/components/Providers/ThemeProvider.client.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Providers/ThemeProvider.client.tsx
@@ -1,10 +1,18 @@
 'use client'
-
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
-import { ThemeProviderProps } from 'next-themes/dist/types.js'
 import React from 'react'
 
 // https://github.com/pacocoursey/next-themes/issues/152#issuecomment-1364280564
-export function ThemeProvider(props: ThemeProviderProps) {
-  return <NextThemesProvider {...props} />
+export function ThemeProvider({ children }) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      disableTransitionOnChange={true}
+      enableSystem
+      value={{ dark: 'dark', light: 'light' }}
+    >
+      {children}
+    </NextThemesProvider>
+  )
 }

--- a/sites/jeromefitzgerald.com/src/components/Quote/Quote.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Quote/Quote.tsx
@@ -18,8 +18,8 @@ function Quote({ item }) {
       asChild
       columns="1"
       height="100%"
-      m={{ initial: '1', lg: '3' }}
-      p={{ initial: '3', lg: '6' }}
+      m={{ initial: '1', md: '3' }}
+      p={{ initial: '3', md: '6' }}
       rows="1"
       width="100%"
     >
@@ -27,7 +27,7 @@ function Quote({ item }) {
         <Box
           className="pointer-events-none -indent-3"
           position="relative"
-          pr={{ initial: '0', lg: '9' }}
+          pr={{ initial: '0', md: '9' }}
           width="100%"
         >
           <Text size="7">

--- a/sites/jeromefitzgerald.com/src/components/Relations/Relations.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Relations/Relations.tsx
@@ -10,7 +10,7 @@ import { RelationsItems, RelationsLoading, getRelationTitle } from './index'
 
 function RelationsWrapper({ children }) {
   return (
-    <Grid columns={{ initial: '2', lg: '3' }} gapX="3" gapY="6" width="100%">
+    <Grid columns={{ initial: '2', md: '3' }} gapX="3" gapY="6" width="100%">
       {children}
     </Grid>
   )

--- a/sites/jeromefitzgerald.com/src/components/Testing/Testing.tsx
+++ b/sites/jeromefitzgerald.com/src/components/Testing/Testing.tsx
@@ -70,7 +70,7 @@ function Testing() {
               <Box
                 asChild
                 key={`homepage-link-${i}`}
-                mb={{ initial: '2', lg: '1' }}
+                mb={{ initial: '2', md: '1' }}
                 my="1"
                 py="1"
               >

--- a/sites/jeromefitzgerald.com/src/data/socials.tsx
+++ b/sites/jeromefitzgerald.com/src/data/socials.tsx
@@ -1,5 +1,5 @@
 import {
-  CloudIcon,
+  BlueskyLogoIcon,
   ExternalLinkIcon,
   GitHubLogoIcon,
   InstagramLogoIcon,
@@ -36,7 +36,7 @@ const socials = [
   {
     active: true,
     className: 'hover:bg-bluesky',
-    icon: <CloudIcon className="text-inherit" />,
+    icon: <BlueskyLogoIcon className="text-inherit" />,
     id: 'bluesky',
     keywords: 'social bluesky',
     rightSlot: <ExternalLinkIcon />,

--- a/sites/jeromefitzgerald.com/src/store/index.tsx
+++ b/sites/jeromefitzgerald.com/src/store/index.tsx
@@ -43,8 +43,8 @@ const getDefaultInitialStateStoreMenu = () => ({
   isCmdkInnerOpenSet: () => {},
   isCmdkOpen: false,
   isCmdkOpenSet: () => {},
-  isMenuOpen: false,
-  isMenuOpenSet: () => {},
+  isMenuMobileOpen: false,
+  isMenuMobileOpenSet: () => {},
   isRouteChanging: false,
   isRouteChangingSet: () => {},
   isWidgetOpen: false,
@@ -106,9 +106,9 @@ const initializeStoreMenu = (preloadedState: Partial<any> = {}) => {
             isCmdkOpen: !get().isCmdkOpen,
           })
     },
-    isMenuOpenSet: () => {
+    isMenuMobileOpenSet: () => {
       set({
-        isMenuOpen: !get().isMenuOpen,
+        isMenuMobileOpen: !get().isMenuMobileOpen,
       })
     },
     isRouteChangingSet: (val: boolean) => {


### PR DESCRIPTION
- [x] ♻️  NICE-75 (layout) `Footer` refactor
- [x] ~~♻️  NICE-75  (next) `next-themes` no longer needs to be called w/in client~~
- [x] ♻️   NICE-75 (tailwind) back to `md` away from `lg`  
- [x]  ♻️  NICE-75 (radix) add skeleton and some more tweaks 
- [x]  ♻️  NICE-75 (radix) fix navigation menu (kind of)    
- [x]  ♻️  NICE-75 (icon) add bluesky (even though like everything else, I barely use) 🦋