### PR TITLE
🩹  (spotify) medium_term [b]

### DIFF
--- a/sites/jeromefitzgerald.com/src/app/(notion)/music/_components/Music.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/music/_components/Music.client.tsx
@@ -87,7 +87,7 @@ const info = {
 const INIT = {
   limit: 10,
   offset: 0,
-  time_range: 'short_term',
+  time_range: 'medium_term',
   type: 'top-artists',
   url: '/api/v1/music',
 }

--- a/sites/jeromefitzgerald.com/src/store/index.tsx
+++ b/sites/jeromefitzgerald.com/src/store/index.tsx
@@ -53,7 +53,7 @@ const getDefaultInitialStateStoreMenu = () => ({
   seenSetDecrease: () => {},
   seenSetIncrease: () => {},
   // @note(zustand) no persist state due to SSR
-  spotifyTimeRange: 'short_term',
+  spotifyTimeRange: 'medium_term',
   spotifyTimeRangeSet: () => {},
   spotifyType: 'top-tracks',
   spotifyTypeSet: () => {},


### PR DESCRIPTION
Swap to default setting of: `medium_term`

Empty results on `./music` looks odd.

Have been using more `radiooooooooooooooOOoOOooooooo`, `bandcamp`, and "old-school" MP3s/FLAC.