### PR TITLE
🐛  (notion) (╯°□°)╯︵ ┻━┻ Slug.Preview [b]

### DIFF
--- a/sites/jeromefitzgerald.com/src/app/(notion)/_config/Event.utils.ts
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/_config/Event.utils.ts
@@ -5,6 +5,8 @@ import { getPropertyTypeData } from 'next-notion/utils/index'
 
 import type { PropertiesEvent } from '@/app/(notion)/_config/index'
 
+// @todo(complexity) 11
+// eslint-disable-next-line complexity
 function getEventData(properties) {
   // if (!properties) return {}
   /**
@@ -49,6 +51,12 @@ function getEventData(properties) {
   )
   const isEventOver = hoursUntilEvent < 0
 
+  const isSeoImageEmpty =
+    getPropertyTypeDataEvent(properties, 'SEO.Image')?.length === 0
+  // console.dir(`what is happening with SEO.Image?!`)
+  // console.dir(`isSeoImageEmpty: ${isSeoImageEmpty ? 'y' : 'n'}`)
+  // console.dir(getPropertyTypeDataEvent(properties, 'SEO.Image'))
+
   const data = {
     dateIso: getPropertyTypeDataEvent(properties, 'Date.ISO'),
     dayOfMonth: getPropertyTypeDataEvent(properties, 'Date.DayOfMonth'),
@@ -71,7 +79,9 @@ function getEventData(properties) {
     monthName: getPropertyTypeDataEvent(properties, 'Date.MonthName'),
     monthNameAbbr: getPropertyTypeDataEvent(properties, 'Date.MonthNameAbbr'),
     seoDescription: getPropertyTypeDataEvent(properties, 'SEO.Description'),
-    seoImage: getPropertyTypeDataEvent(properties, 'SEO.Image')[0],
+    seoImage: isSeoImageEmpty
+      ? null
+      : getPropertyTypeDataEvent(properties, 'SEO.Image')[0],
     seoImageDescription: getPropertyTypeDataEvent(
       properties,
       'SEO.Image.Description',

--- a/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Slug.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/events/[[...catchAll]]/_components/Event.Slug.tsx
@@ -99,6 +99,8 @@ async function Slug({ revalidate, segmentInfo }) {
   const noData = isObjectEmpty(data?.blocks || {})
   const is404 = noData
 
+  // console.dir(segmentInfo)
+  // console.dir(data)
   // console.dir(`noData:           ${noData ? 'y' : 'n'}`)
   // console.dir(`is404:            ${is404 ? 'y' : 'n'}`)
 


### PR DESCRIPTION
(╯°□°)╯︵ ┻━┻ `Slug.Preview`

```bash
join(["", "events", formatDate(dateSubtract(prop("Date"), 5, "hours"), "YYYY/MM/DD"), prop("Slug")], "/")
```

API User is UTC, so basically account for highest diff in Eastern Timezone with UTC instead of `1` day.

This seems to nly work with blowing out cache and doing a check for SEO Image now. (－‸ლ)