### PR TITLE
🐛  NICE-135 limit for recently-played [b]

### DIFF
--- a/sites/jeromefitzgerald.com/src/app/(notion)/currently/listening-to/_components/Music.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/currently/listening-to/_components/Music.client.tsx
@@ -26,6 +26,8 @@ import {
 } from '@radix-ui/themes/dist/esm/components/select.js'
 import { Strong } from '@radix-ui/themes/dist/esm/components/strong.js'
 import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
+// import { getUnixTime } from 'date-fns'
+// import _last from 'lodash/last.js'
 import Image from 'next/image'
 // eslint-disable-next-line no-restricted-imports
 import NextLink from 'next/link'
@@ -417,6 +419,7 @@ function DataItems() {
 
   const { spotifyTimeRange, spotifyType } = useStore()
 
+  // const [before] = useState(getUnixTime(Date.now()))
   const [limit] = useState(10)
   const [url] = useState(INIT.url)
 
@@ -454,6 +457,16 @@ function DataItems() {
       revalidateOnReconnect: false,
     },
   )
+
+  // if (spotifyType === 'recently-played') {
+  //   console.dir(`before: ${before}`)
+  //   console.dir(`cursors.before:`)
+  //   console.dir(data[0].played_at)
+  //   const bFirst = getUnixTime(data[0]?.played_at)
+  //   const bLast = getUnixTime(_last(data).played_at)
+  //   console.dir(`bFirst: ${bFirst}000`)
+  //   console.dir(`bLast:  ${bLast}000`)
+  // }
 
   useEffect(() => {
     if (

--- a/sites/jeromefitzgerald.com/src/app/(notion)/currently/listening-to/_components/Music.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/currently/listening-to/_components/Music.client.tsx
@@ -66,16 +66,12 @@ function addS(str) {
   return `${str}’${poss}`
 }
 
-/**
- * @todo(spotify) uh... what is going on with short_term ?
- */
 const ranges = [
-  { active: false, slug: 'short_term', title: 'Past Month' },
+  { active: true, slug: 'short_term', title: 'Past Month' },
   {
     active: true,
     slug: 'medium_term',
-    // title: 'Past Six Months',
-    title: 'Recent',
+    title: 'Past Six Months',
   },
   { active: true, slug: 'long_term', title: 'All Time' },
 ]
@@ -135,6 +131,7 @@ function DataItem({ item, type }) {
   }
   const genres = getArrayFirstX(_genres, GENRE_MAX)
   const genresExtra = getArrayCountOfOverage(_genres, GENRE_MAX)
+  const isTrack = ['recently-played', 'top-tracks'].includes(type)
 
   return (
     <>
@@ -157,7 +154,7 @@ function DataItem({ item, type }) {
               </Text>
             </DataList.Value>
           </DataList.Item>
-          {['recently-played', 'top-tracks'].includes(type) && (
+          {isTrack && (
             <>
               <DataList.Item align="start" className="flex flex-col gap-0">
                 <DataList.Label>
@@ -203,7 +200,7 @@ function DataItem({ item, type }) {
             align="start"
             className={cx(
               'flex-col gap-0 md:gap-1',
-              type === 'top-tracks' ? 'hidden' : 'flex',
+              type === isTrack ? 'hidden' : 'flex',
             )}
           >
             <DataList.Label>
@@ -435,7 +432,7 @@ function DataItems() {
   } = useSWRInfinitePages(
     (pageIndex) =>
       getKey(pageIndex, {
-        limit,
+        limit: spotifyType === 'recently-played' ? 50 : limit,
         time_range: spotifyTimeRange ?? INIT.time_range,
         type: spotifyType ?? INIT.type,
         url,
@@ -444,7 +441,7 @@ function DataItems() {
     {
       // @ts-ignore
       dataPath: 'items',
-      limit: 10,
+      limit: spotifyType === 'recently-played' ? 50 : limit,
       //
       refreshInterval: HOUR,
       revalidateAll: false,

--- a/sites/jeromefitzgerald.com/src/app/(notion)/currently/listening-to/_components/Music.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(notion)/currently/listening-to/_components/Music.client.tsx
@@ -26,8 +26,6 @@ import {
 } from '@radix-ui/themes/dist/esm/components/select.js'
 import { Strong } from '@radix-ui/themes/dist/esm/components/strong.js'
 import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
-// import { getUnixTime } from 'date-fns'
-// import _last from 'lodash/last.js'
 import Image from 'next/image'
 // eslint-disable-next-line no-restricted-imports
 import NextLink from 'next/link'
@@ -419,7 +417,6 @@ function DataItems() {
 
   const { spotifyTimeRange, spotifyType } = useStore()
 
-  // const [before] = useState(getUnixTime(Date.now()))
   const [limit] = useState(10)
   const [url] = useState(INIT.url)
 
@@ -457,16 +454,6 @@ function DataItems() {
       revalidateOnReconnect: false,
     },
   )
-
-  // if (spotifyType === 'recently-played') {
-  //   console.dir(`before: ${before}`)
-  //   console.dir(`cursors.before:`)
-  //   console.dir(data[0].played_at)
-  //   const bFirst = getUnixTime(data[0]?.played_at)
-  //   const bLast = getUnixTime(_last(data).played_at)
-  //   console.dir(`bFirst: ${bFirst}000`)
-  //   console.dir(`bLast:  ${bLast}000`)
-  // }
 
   useEffect(() => {
     if (

--- a/sites/jeromefitzgerald.com/src/app/api/v1/music/[slug]/route.ts
+++ b/sites/jeromefitzgerald.com/src/app/api/v1/music/[slug]/route.ts
@@ -57,7 +57,7 @@ const getKey = ({ limit, offset, slug, time_range }) => {
   }
 
   if (slug === 'recently-played') {
-    const _params = `?limit=50`
+    const _params = `?limit=${limit}`
     const params = _slug(_params)
     const key = `${keyPrefixSpotify}/${slug}/${params}`.toLowerCase()
     return {

--- a/sites/jeromefitzgerald.com/src/app/playground/2024/_components/Currently.Music.Client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/playground/2024/_components/Currently.Music.Client.tsx
@@ -13,7 +13,7 @@ import { CurrentlyItem } from './Currently.Item'
 import { CurrentlyWrapper } from './Currently.Item.Wrapper'
 
 // const key = getKey(0, { ...INIT, time_range: 'short_term', type: 'top-tracks' })
-const key = getKey(0, { ...INIT, limit: 50, type: 'recently-played' })
+const key = getKey(0, { ...INIT, limit: 1, type: 'recently-played' })
 
 const options = {}
 

--- a/sites/jeromefitzgerald.com/src/utils/getKey.ts
+++ b/sites/jeromefitzgerald.com/src/utils/getKey.ts
@@ -1,5 +1,15 @@
 /**
  * Spotify API
+ *
+ * @todo(spotify)
+ *
+ * recently-played cursor is: after|before
+ * - its history is 50 records
+ * - no need to cycle through cursors indefinetly
+ * - just request limit of 50
+ *
+ * top-artists|tracks cursor is: offset
+ * - works well with pageIndex
  */
 const getKey = (pageIndex, { limit, time_range, type, url }) => {
   const offset = pageIndex === 0 ? 0 : 10 * pageIndex


### PR DESCRIPTION
Use `1` for **Homepage** (Homepage)
Use `50` for **Currently** (Recently Played)

API only allows going back ~50 records (which is the limit). Instead of finagling a way to dynamically load based on [`cursors.before|after`](https://developer.spotify.com/documentation/web-api/reference/get-recently-played) do the above.

If we ever want to limit back down to `10` and cycle through do some finagling via:

```bash
# get last item time in ms (add 000)
before: `${getUnixTime(_last(data).played_at)}000`
```