### PR TITLE
🩹  (notion) page_size 50; !has_more if events [b]

### DIFF
--- a/packages/next-notion/src/queries/getBlockChildrenData.ts
+++ b/packages/next-notion/src/queries/getBlockChildrenData.ts
@@ -8,7 +8,7 @@ import { notion } from '../helper'
 async function getBlockChildrenData(block_id) {
   const response = await notion.blocks.children.list({
     block_id,
-    page_size: 100, // max
+    page_size: 50,
   })
   return response
 }


### PR DESCRIPTION
Seems like adding `1` more event was the straw that broke the camel's back here.

But all the same probably _do not_ need to be caching so many events, I am with you upstash.

Look into breaking it down by years. To just grab the latest it would be more ideal to hit up:

`./notion/queries/events/events/[CURRENT_YEAR]`

Rather than _all of them_. So perhaps do that next. You can always then _join_ multiple years for longer-term. Heck even `CURRENT_YEAR-1` is probably fine.