### PR TITLE
🔧  npmrc for mend renovate [skip ci]

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Until **Mend Renovate** can read `registry|registries` from `pnpm-workspace.yaml` re-introduce it to see if picks back up (#4126)