### PR TITLE
🐛  dupe css; node-emoji ssr only [b]

### DIFF
--- a/sites/jeromefitzgerald.com/src/app/layout.tsx
+++ b/sites/jeromefitzgerald.com/src/app/layout.tsx
@@ -20,7 +20,6 @@ import { fonts } from "./_next/fonts";
 import { PreloadResources } from "./_next/preload-resources";
 // import { KitchenSink } from './_v16/kitchen-sink'
 
-import "@radix-ui/themes/styles.css";
 import "./styles--globals.css";
 
 export const metadata: Metadata = {

--- a/sites/jeromefitzgerald.com/src/components/container/container.footer.client.tsx
+++ b/sites/jeromefitzgerald.com/src/components/container/container.footer.client.tsx
@@ -6,8 +6,6 @@ import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
 import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
 import { usePathname } from "next/navigation.js";
 
-import { NotionEmoji as EmojiWrapper } from "@/lib/notion/blocks/emoji";
-
 const IS_COLOPHON_SHOWN = false;
 
 function ContainerFooterClient() {
@@ -36,9 +34,7 @@ function ContainerFooterClient() {
           className="font-mono md:mr-1"
           size={{ initial: "1", md: "2" }}
         >
-          <Text className="mr-0 size-4 font-sans md:mr-2">
-            <EmojiWrapper id={`no-need-2`} text={`©`} />
-          </Text>
+          <Text className="mr-0 size-4 font-sans md:mr-2">©</Text>
           <Box as="span" display="inline">
             <Text>Nice Group of People, LLC –&nbsp;</Text>
             <Text className="">{new Date().getFullYear()}</Text>

--- a/sites/jeromefitzgerald.com/src/config/next.config.env.client.ts
+++ b/sites/jeromefitzgerald.com/src/config/next.config.env.client.ts
@@ -1,61 +1,27 @@
-// @ts-check
 /**
  * ref: https://vercel.com/docs/projects/environment-variables/system-environment-variables
  *
  */
-import { z } from "zod";
 
 const SITE = "jeromefitzgerald.com";
-const SITE_HTTPS = `https://${SITE}`;
 
-const envSchema = z.object({
-  IS_DEV: z.boolean(),
-  IS_PRODUCTION: z.boolean(),
-  IS_VERCEL: z.boolean(),
-  NEXT_PUBLIC__APPLE_IDENTIFIER: z.string().trim(),
-  NEXT_PUBLIC__APPLE_TOKEN_DEVELOPER: z.string().trim(),
-  NEXT_PUBLIC__BASE_URL: z.enum([SITE_HTTPS]).default(SITE_HTTPS),
-  NEXT_PUBLIC__FATHOM_SITE_ID: z.string().trim(),
-  NEXT_PUBLIC__SITE: z.enum([SITE]).default(SITE),
-  NEXT_PUBLIC_HOST_NAME: z.string().trim().optional(),
-  NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: z.string().trim().optional(),
-  NEXT_PUBLIC_VERCEL_URL: z.string().trim().optional(),
-  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
-  OVERRIDE_CACHE: z
-    .string()
-    .transform((value) => ["1", "on", "true", "yes"].includes(value.toLowerCase()))
-    .default(false),
-  VERCEL_ENV: z.enum(["development", "production", "preview"]).default("development"),
-});
-
-const envClientParsed = envSchema.safeParse({
+const envClient = Object.freeze({
   IS_DEV: process.env.NODE_ENV === "development",
   IS_PRODUCTION: process.env.NODE_ENV === "production",
-  IS_VERCEL: !!process.env.VERCEL_URL,
+  IS_VERCEL: !!process.env.NEXT_PUBLIC_VERCEL_URL,
   NEXT_PUBLIC__APPLE_IDENTIFIER: process.env.NEXT_PUBLIC__APPLE_IDENTIFIER ?? "",
   NEXT_PUBLIC__APPLE_TOKEN_DEVELOPER: process.env.NEXT_PUBLIC__APPLE_TOKEN_DEVELOPER ?? "",
-  NEXT_PUBLIC__BASE_URL: `https://${process.env.NEXT_PUBLIC__SITE}`,
-  NEXT_PUBLIC__FATHOM_SITE_ID: process.env.NEXT_PUBLIC__FATHOM_SITE_ID,
-  NEXT_PUBLIC__SITE: process.env.NEXT_PUBLIC__SITE,
+  NEXT_PUBLIC__BASE_URL: `https://${process.env.NEXT_PUBLIC__SITE ?? SITE}`,
+  NEXT_PUBLIC__FATHOM_SITE_ID: process.env.NEXT_PUBLIC__FATHOM_SITE_ID ?? "",
+  NEXT_PUBLIC__SITE: process.env.NEXT_PUBLIC__SITE ?? SITE,
   NEXT_PUBLIC_HOST_NAME: process.env.NEXT_PUBLIC_HOST_NAME,
   NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF,
   NEXT_PUBLIC_VERCEL_URL: process.env.NEXT_PUBLIC_VERCEL_URL,
-  NODE_ENV: process.env.NODE_ENV,
-  OVERRIDE_CACHE: process.env.OVERRIDE_CACHE,
-  VERCEL_ENV: process.env.VERCEL_ENV,
+  NODE_ENV: (process.env.NODE_ENV ?? "development") as "development" | "production" | "test",
+  OVERRIDE_CACHE: ["1", "on", "true", "yes"].includes(
+    (process.env.OVERRIDE_CACHE ?? "").toLowerCase(),
+  ),
+  VERCEL_ENV: (process.env.VERCEL_ENV ?? "development") as "development" | "production" | "preview",
 });
-
-if (!envClientParsed.success) {
-  console.error(
-    `- warn [ ⚠️ ] (client) Missing or invalid environment variable${
-      envClientParsed.error.issues.length > 1 ? "s" : ""
-    }:
-${envClientParsed.error.issues.map((issue) => `  ${issue.path}: ${issue.message}`).join("\n")}
-`,
-  );
-  process.exit(1);
-}
-
-const envClient = Object.freeze(envClientParsed.data);
 
 export { envClient };

--- a/sites/jeromefitzgerald.com/src/lib/notion/blocks/emoji.server.tsx
+++ b/sites/jeromefitzgerald.com/src/lib/notion/blocks/emoji.server.tsx
@@ -1,3 +1,4 @@
+import "server-only";
 import emojiRegex from "emoji-regex";
 import { map as _map, orderBy as _orderBy, size as _size } from "lodash-es";
 import { find as findEmoji } from "node-emoji";

--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,10 @@
       "inputs": ["src/**", "*.cjs", "*.js", "*.mjs", "tsdown.config.ts", "tsconfig.json"],
       "outputs": ["dist/**"]
     },
+    "build:analyze": {
+      "cache": false,
+      "dependsOn": ["^build"]
+    },
     "jeromefitzgerald.com#build": {
       "dependsOn": ["^build"],
       "env": ["VERCEL_ENV"],


### PR DESCRIPTION
## 🔥 dupe css

This is already imported in `./packages/tailwind-config/styles/radix-themes-tw.css` and should reduce/remove this:

> Reduce unused CSS Est savings of 73 KiB

### Update:

It did! ☺️

## 🐛  node-emoji ssr only

Well, shoot. I was doing this all wrong. Well half-wrong. The half-that is client side, heh. Low-tech the Copyright for Footer to make that easier. But then guard emoji.server and not do the ... admittedly stuff that works but loads like... `60 KiB compressed`

Should reduce/ remove this:

> Reduce unused JavaScript Est savings of 72 KiB

### Update:

It did not! 🫩
