### PR TITLE
♻️  @radix-ui/themes@3.3.0 imports [skip ci]

### DIFF
--- a/packages/design-system/src/components/anchor/anchor.tsx
+++ b/packages/design-system/src/components/anchor/anchor.tsx
@@ -1,6 +1,5 @@
 import { envClient } from "@jeromefitz/next-config";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
+import { Flex, Link } from "@radix-ui/themes";
 import NextLink from "next/link";
 
 import { ExternalLinkIcon } from "../icon/icon";

--- a/packages/design-system/src/components/callout/callout.tsx
+++ b/packages/design-system/src/components/callout/callout.tsx
@@ -1,9 +1,4 @@
-import type { RootProps as CalloutRootProps } from "@radix-ui/themes/dist/esm/components/callout.js";
-import {
-  Icon as CalloutIcon,
-  Root as CalloutRoot,
-  Text as CalloutText,
-} from "@radix-ui/themes/dist/esm/components/callout.js";
+import { Callout } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 
 import { cx } from "../../utils/cx";
@@ -16,7 +11,7 @@ interface AdditionalProps {
   color?: string;
   icon?: any;
 }
-type CalloutRootPropsImpl = AdditionalProps & CalloutRootProps;
+type CalloutRootPropsImpl = AdditionalProps & Callout.RootProps;
 
 function CalloutImpl({
   children = <>This page is in the process of being updated.</>,
@@ -28,17 +23,17 @@ function CalloutImpl({
   variant = "soft",
 }: CalloutRootPropsImpl) {
   return (
-    <CalloutRoot
+    <Callout.Root
       className={cx("w-full font-mono", className)}
       color={color}
       size={size}
       variant={variant}
     >
-      <CalloutIcon>
+      <Callout.Icon>
         <Icon />
-      </CalloutIcon>
-      <CalloutText className={classNameText}>{children}</CalloutText>
-    </CalloutRoot>
+      </Callout.Icon>
+      <Callout.Text className={classNameText}>{children}</Callout.Text>
+    </Callout.Root>
   );
 }
 

--- a/packages/design-system/src/components/skip-nav/skip-nav.tsx
+++ b/packages/design-system/src/components/skip-nav/skip-nav.tsx
@@ -1,5 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
+import { Box, Link } from "@radix-ui/themes";
 import type { Ref } from "react";
 
 import { cx } from "../../utils/cx";

--- a/sites/jerandky.com/src/app/(notion)/podcasts/[[...catchAll]]/_components/episode.slug.tsx
+++ b/sites/jerandky.com/src/app/(notion)/podcasts/[[...catchAll]]/_components/episode.slug.tsx
@@ -13,11 +13,8 @@ import { cx } from "@jeromefitz/ds/utils/cx";
 import { EmbedSpotify } from "@jeromefitz/shared/components/notion/blocks/embed.spotify";
 import { getDataFromCache } from "@jeromefitz/shared/notion/utils";
 import { isObjectEmpty } from "@jeromefitz/utils";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
+import { Box, Separator, Strong, Text } from "@radix-ui/themes";
 // import { Grid } from '@radix-ui/themes/dist/esm/components/grid.js'
-import { Separator } from "@radix-ui/themes/dist/esm/components/separator.js";
-import { Strong } from "@radix-ui/themes/dist/esm/components/strong.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
 import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 

--- a/sites/jerandky.com/src/app/_errors/404.tsx
+++ b/sites/jerandky.com/src/app/_errors/404.tsx
@@ -8,7 +8,7 @@ import {
   // Tags,
 } from "@jeromefitz/ds/components/section";
 import { isObjectEmpty } from "@jeromefitz/utils";
-import { Separator } from "@radix-ui/themes/dist/esm/components/separator.js";
+import { Separator } from "@radix-ui/themes";
 
 // @todo(types)
 function FourOhFour({

--- a/sites/jerandky.com/src/components/error-boundary/error-boundary.tsx
+++ b/sites/jerandky.com/src/components/error-boundary/error-boundary.tsx
@@ -7,7 +7,7 @@ import {
   SectionWrapper,
   // Tags,
 } from "@jeromefitz/ds/components/section";
-import { Separator } from "@radix-ui/themes/dist/esm/components/separator.js";
+import { Separator } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 import { Component } from "react";
 

--- a/sites/jeromefitzgerald.com/src/app/(pages)/about/_components/section.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(pages)/about/_components/section.client.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
+import { Box } from "@radix-ui/themes";
 import NextLink from "next/link";
 
 function SectionClientLegend({ data }: { data: any }) {

--- a/sites/jeromefitzgerald.com/src/app/(pages)/about/_components/section.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(pages)/about/_components/section.tsx
@@ -1,14 +1,16 @@
 import { ExternalLinkIcon } from "@jeromefitz/ds/components/icon";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
-import { Separator } from "@radix-ui/themes/dist/esm/components/separator.js";
-import { Strong } from "@radix-ui/themes/dist/esm/components/strong.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import {
+  Box,
+  Button,
+  Code,
+  Em,
+  Flex,
+  Heading,
+  Link,
+  Separator,
+  Strong,
+  Text,
+} from "@radix-ui/themes";
 import NextLink from "next/link";
 import { Fragment } from "react";
 

--- a/sites/jeromefitzgerald.com/src/app/(pages)/about/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(pages)/about/page.tsx
@@ -1,7 +1,5 @@
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Em, Flex, Text } from "@radix-ui/themes";
 // import { Strong } from '@radix-ui/themes/dist/esm/components/strong.js'
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
 import type { Metadata, ResolvingMetadata } from "next";
 import { notFound } from "next/navigation.js";
 

--- a/sites/jeromefitzgerald.com/src/app/(pages)/colophon/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(pages)/colophon/page.tsx
@@ -1,5 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
+import { Flex, Heading } from "@radix-ui/themes";
 import type { Metadata, ResolvingMetadata } from "next";
 import { notFound } from "next/navigation.js";
 

--- a/sites/jeromefitzgerald.com/src/app/(pages)/currently/listening-to/_components/music.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(pages)/currently/listening-to/_components/music.client.tsx
@@ -2,22 +2,19 @@
 
 import { ExternalLinkIcon } from "@jeromefitz/ds/components/icon";
 import { useIntersection } from "@mantine/hooks";
-import { Badge } from "@radix-ui/themes/dist/esm/components/badge.js";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import * as DataList from "@radix-ui/themes/dist/esm/components/data-list.js";
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Inset } from "@radix-ui/themes/dist/esm/components/inset.js";
 import {
-  Content as SelectContent,
-  Item as SelectItem,
-  Root as SelectRoot,
-  Trigger as SelectTrigger,
-} from "@radix-ui/themes/dist/esm/components/select.js";
-import { Strong } from "@radix-ui/themes/dist/esm/components/strong.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+  Badge,
+  Box,
+  Button,
+  Code,
+  DataList,
+  Em,
+  Flex,
+  Inset,
+  Select,
+  Strong,
+  Text,
+} from "@radix-ui/themes";
 import Image from "next/image";
 import NextLink from "next/link";
 import { useEffect, useRef, useState } from "react";
@@ -600,20 +597,20 @@ function MusicClient() {
                 <Flex gap="3">
                   {/* @todo(radix) children */}
                   {/* @ts-ignore */}
-                  <SelectRoot
+                  <Select.Root
                     defaultValue={appleMusicType ?? INIT.type}
                     onValueChange={(value: string) => handleValueChangeType(value)}
                     size="3"
                   >
-                    <SelectTrigger className="!md:w-full z-50 !w-full" placeholder="Type:" />
-                    <SelectContent className="z-50 w-full" position="popper">
-                      {/* <SelectItem value="history-heavy-rotation">
+                    <Select.Trigger className="!md:w-full z-50 !w-full" placeholder="Type:" />
+                    <Select.Content className="z-50 w-full" position="popper">
+                      {/* <Select.Item value="history-heavy-rotation">
                         Heavy Rotation
-                      </SelectItem> */}
-                      <SelectItem value="recent-played-albums">Recently Played Albums</SelectItem>
-                      <SelectItem value="recent-played-tracks">Recently Played Tracks</SelectItem>
-                    </SelectContent>
-                  </SelectRoot>
+                      </Select.Item> */}
+                      <Select.Item value="recent-played-albums">Recently Played Albums</Select.Item>
+                      <Select.Item value="recent-played-tracks">Recently Played Tracks</Select.Item>
+                    </Select.Content>
+                  </Select.Root>
                 </Flex>
               </Flex>
             </Flex>

--- a/sites/jeromefitzgerald.com/src/app/(pages)/currently/reading/_components/book.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(pages)/currently/reading/_components/book.client.tsx
@@ -2,22 +2,19 @@
 
 import { ExternalLinkIcon } from "@jeromefitz/ds/components/icon";
 import { lpad } from "@jeromefitz/utils";
-import { Badge } from "@radix-ui/themes/dist/esm/components/badge.js";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import * as DataList from "@radix-ui/themes/dist/esm/components/data-list.js";
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Inset } from "@radix-ui/themes/dist/esm/components/inset.js";
 import {
-  Content as SelectContent,
-  Item as SelectItem,
-  Root as SelectRoot,
-  Trigger as SelectTrigger,
-} from "@radix-ui/themes/dist/esm/components/select.js";
-import { Strong } from "@radix-ui/themes/dist/esm/components/strong.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+  Badge,
+  Box,
+  Button,
+  Code,
+  DataList,
+  Em,
+  Flex,
+  Inset,
+  Select,
+  Strong,
+  Text,
+} from "@radix-ui/themes";
 import { format, parseISO } from "date-fns";
 import { slug as _slug } from "github-slugger";
 import { orderBy as _orderBy } from "lodash-es";
@@ -417,16 +414,16 @@ function BookPage({ items }: { items: any }) {
           <>
             {/* @todo(radix) children */}
             {/* @ts-ignore */}
-            <SelectRoot
+            <Select.Root
               defaultValue={bookStatus ?? "in-progress"}
               onValueChange={(value: any) => handleValueChangeBookStatus(value)}
               size={{ initial: "3", md: "3" }}
             >
-              <SelectTrigger className="w-full hover:cursor-pointer" placeholder="Time Range:" />
-              <SelectContent className="z-50 w-full" position="popper">
+              <Select.Trigger className="w-full hover:cursor-pointer" placeholder="Time Range:" />
+              <Select.Content className="z-50 w-full" position="popper">
                 {books.map((book: any) => {
                   return (
-                    <SelectItem
+                    <Select.Item
                       className="group hover:cursor-pointer"
                       key={`si--${book.id}`}
                       value={book.id}
@@ -448,11 +445,11 @@ function BookPage({ items }: { items: any }) {
                           <Text>{book.title}</Text>
                         </Box>
                       </Flex>
-                    </SelectItem>
+                    </Select.Item>
                   );
                 })}
-              </SelectContent>
-            </SelectRoot>
+              </Select.Content>
+            </Select.Root>
             <Callout className="relative right-0 bottom-0" color="mint" size="1">
               <Strong className="font-mono uppercase">Bookshop</Strong> links earn a commission.
             </Callout>

--- a/sites/jeromefitzgerald.com/src/app/(segments)/blog/[...key]/_components/blog.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/blog/[...key]/_components/blog.tsx
@@ -1,8 +1,5 @@
 import { TZDate } from "@date-fns/tz";
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Code, Flex, Heading, Text } from "@radix-ui/themes";
 import { format } from "date-fns";
 
 import { ImageNotion } from "@/components/image/image.notion";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/blog/_components/list.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/blog/_components/list.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Flex, Heading, Link, Text } from "@radix-ui/themes";
 import NextLink from "next/link";
 
 import type { Blog } from "@/lib/drizzle/schemas/cache-blogs/types";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/books/[key]/_components/book.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/books/[key]/_components/book.tsx
@@ -1,8 +1,5 @@
 import { TZDate } from "@date-fns/tz";
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Code, Flex, Heading, Text } from "@radix-ui/themes";
 import { format } from "date-fns";
 
 import { ImageNotion } from "@/components/image/image.notion";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/books/_components/list.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/books/_components/list.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Flex, Heading, Link, Text } from "@radix-ui/themes";
 import NextLink from "next/link";
 
 import type { Book } from "@/lib/drizzle/schemas/cache-books/types";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/events/[...key]/_components/event.data.list.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/events/[...key]/_components/event.data.list.tsx
@@ -7,14 +7,7 @@ import {
   InfoCircledIcon,
   // TagIcon,
 } from "@jeromefitz/ds/components/icon";
-import { Badge } from "@radix-ui/themes/dist/esm/components/badge.js";
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import * as DataList from "@radix-ui/themes/dist/esm/components/data-list.js";
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Skeleton } from "@radix-ui/themes/dist/esm/components/skeleton.js";
-import { Strong } from "@radix-ui/themes/dist/esm/components/strong.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Badge, Code, DataList, Em, Flex, Skeleton, Strong, Text } from "@radix-ui/themes";
 import { format } from "date-fns";
 
 import { TZ } from "@/config/const";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/events/[...key]/_components/event.slug.header.data.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/events/[...key]/_components/event.slug.header.data.tsx
@@ -1,9 +1,5 @@
 import { ExternalLinkIcon } from "@jeromefitz/ds/components/icon";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Portal } from "@radix-ui/themes/dist/esm/components/portal.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Button, Flex, Portal, Text } from "@radix-ui/themes";
 import { isAfter } from "date-fns/isAfter";
 import NextLink from "next/link";
 

--- a/sites/jeromefitzgerald.com/src/app/(segments)/events/_components/list.client.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/events/_components/list.client.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { ExternalLinkIcon } from "@jeromefitz/ds/components/icon";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Button, Flex, Text } from "@radix-ui/themes";
 import { isAfter } from "date-fns/isAfter";
 import NextLink from "next/link";
 

--- a/sites/jeromefitzgerald.com/src/app/(segments)/events/_components/list.deprecated.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/events/_components/list.deprecated.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Flex, Heading, Text } from "@radix-ui/themes";
 
 import type { NotionText } from "@/lib/drizzle/schemas/_notion/types";
 import type { Event } from "@/lib/drizzle/schemas/cache-events/types";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/events/_components/list.temp.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/events/_components/list.temp.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Flex, Heading, Link, Text } from "@radix-ui/themes";
 import NextLink from "next/link";
 
 import type { Event } from "@/lib/drizzle/schemas/cache-events/types";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/events/_components/list.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/events/_components/list.tsx
@@ -1,16 +1,8 @@
 // import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
 
 import { ExternalLinkIcon } from "@jeromefitz/ds/components/icon";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
+import { Box, Button, Em, Flex, Grid, Heading, Link, Strong, Text } from "@radix-ui/themes";
 // import { Code } from '@radix-ui/themes/dist/esm/components/code.js'
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Grid } from "@radix-ui/themes/dist/esm/components/grid.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
-import { Strong } from "@radix-ui/themes/dist/esm/components/strong.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
 import { isAfter } from "date-fns/isAfter";
 // import { filter as _filter, orderBy as _orderBy, take as _take } from 'lodash-es'
 import { filter as _filter, orderBy as _orderBy } from "lodash-es";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/podcasts/[key]/[key-episode]/_components/episode.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/podcasts/[key]/[key-episode]/_components/episode.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Flex } from "@radix-ui/themes";
 
 import { ShowSlugHeaderData } from "@/app/(segments)/shows/[key]/_components/show.slug.header.data";
 import { ArticleMain } from "@/components/article/article.main";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/podcasts/[key]/_components/podcast.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/podcasts/[key]/_components/podcast.tsx
@@ -1,6 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Flex, Link, Text } from "@radix-ui/themes";
 import NextLink from "next/link";
 
 import { ShowSlugHeaderData } from "@/app/(segments)/shows/[key]/_components/show.slug.header.data";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/podcasts/_components/list.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/podcasts/_components/list.tsx
@@ -1,10 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Grid } from "@radix-ui/themes/dist/esm/components/grid.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Strong } from "@radix-ui/themes/dist/esm/components/strong.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Em, Flex, Grid, Heading, Strong, Text } from "@radix-ui/themes";
 import { filter as _filter, orderBy as _orderBy } from "lodash-es";
 import NextLink from "next/link";
 

--- a/sites/jeromefitzgerald.com/src/app/(segments)/shows/[key]/_components/show.slug.header.data.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/shows/[key]/_components/show.slug.header.data.tsx
@@ -1,10 +1,6 @@
 // import { getShowData } from '@/app/(notion)/_config/index'
 import { IdCardIcon, TagIcon } from "@jeromefitz/ds/components/icon";
-import { Badge } from "@radix-ui/themes/dist/esm/components/badge.js";
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import * as DataList from "@radix-ui/themes/dist/esm/components/data-list.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Badge, Code, DataList, Flex, Text } from "@radix-ui/themes";
 
 import type { NotionTag } from "@/lib/drizzle/schemas/_notion/types";
 import { cx } from "@/utils/cx";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/shows/_components/list.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/shows/_components/list.tsx
@@ -1,12 +1,4 @@
-import { Badge } from "@radix-ui/themes/dist/esm/components/badge.js";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Grid } from "@radix-ui/themes/dist/esm/components/grid.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Strong } from "@radix-ui/themes/dist/esm/components/strong.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Badge, Box, Code, Em, Flex, Grid, Heading, Strong, Text } from "@radix-ui/themes";
 import { filter as _filter, orderBy as _orderBy } from "lodash-es";
 import NextLink from "next/link";
 

--- a/sites/jeromefitzgerald.com/src/app/(segments)/venues/[key]/_components/venue.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/venues/[key]/_components/venue.tsx
@@ -1,6 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Flex, Heading, Text } from "@radix-ui/themes";
 import { format } from "date-fns";
 
 import { ImageNotion } from "@/components/image/image.notion";

--- a/sites/jeromefitzgerald.com/src/app/(segments)/venues/_components/list.tsx
+++ b/sites/jeromefitzgerald.com/src/app/(segments)/venues/_components/list.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Flex, Heading, Link, Text } from "@radix-ui/themes";
 import NextLink from "next/link";
 
 import type { Venue } from "@/lib/drizzle/schemas/cache-venues/types";

--- a/sites/jeromefitzgerald.com/src/app/auth/apple-music/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/auth/apple-music/page.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Separator } from "@radix-ui/themes/dist/esm/components/separator.js";
-import { Strong } from "@radix-ui/themes/dist/esm/components/strong.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Button, Code, Flex, Separator, Strong, Text } from "@radix-ui/themes";
 import { envClient } from "next-config/env.client";
 import { useEffect, useState } from "react";
 

--- a/sites/jeromefitzgerald.com/src/app/layout.tsx
+++ b/sites/jeromefitzgerald.com/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Theme } from "@radix-ui/themes/dist/esm/components/theme.js";
+import { Theme } from "@radix-ui/themes";
 import { isAfter } from "date-fns/isAfter";
 import { filter as _filter, orderBy as _orderBy, take as _take } from "lodash-es";
 import type { Metadata } from "next";

--- a/sites/jeromefitzgerald.com/src/app/not-found.tsx
+++ b/sites/jeromefitzgerald.com/src/app/not-found.tsx
@@ -1,7 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Flex, Heading, Link, Text } from "@radix-ui/themes";
 import NextLink from "next/link";
 
 export default function NotFound() {

--- a/sites/jeromefitzgerald.com/src/app/page.tsx
+++ b/sites/jeromefitzgerald.com/src/app/page.tsx
@@ -1,12 +1,10 @@
 // import { Badge } from '@radix-ui/themes/dist/esm/components/badge.js'
 // import { Box } from '@radix-ui/themes/dist/esm/components/box.js'
 // import { Code } from '@radix-ui/themes/dist/esm/components/code.js'
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Em, Flex, Text } from "@radix-ui/themes";
 // import { Grid } from '@radix-ui/themes/dist/esm/components/grid.js'
 // import { Heading } from '@radix-ui/themes/dist/esm/components/heading.js'
 // import { Strong } from '@radix-ui/themes/dist/esm/components/strong.js'
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
 import type { Metadata, ResolvingMetadata } from "next";
 
 import { ArticleMain } from "@/components/article/article.main";

--- a/sites/jeromefitzgerald.com/src/components/anchor/anchor.tsx
+++ b/sites/jeromefitzgerald.com/src/components/anchor/anchor.tsx
@@ -1,6 +1,5 @@
 import { ExternalLinkIcon } from "@jeromefitz/ds/components/icon";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
+import { Flex, Link } from "@radix-ui/themes";
 import { envClient as env } from "next-config/env.client";
 import NextLink from "next/link";
 

--- a/sites/jeromefitzgerald.com/src/components/article/article.main.cta.tsx
+++ b/sites/jeromefitzgerald.com/src/components/article/article.main.cta.tsx
@@ -1,9 +1,5 @@
 import { ArrowTopRightIcon } from "@jeromefitz/ds/components/icon";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
+import { Box, Button, Em, Flex, Heading } from "@radix-ui/themes";
 import NextLink from "next/link";
 
 import { cx } from "@/utils/cx";

--- a/sites/jeromefitzgerald.com/src/components/article/article.main.tsx
+++ b/sites/jeromefitzgerald.com/src/components/article/article.main.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Flex } from "@radix-ui/themes";
 
 /**
  * @todo(a11y) should this be article instead of main

--- a/sites/jeromefitzgerald.com/src/components/callout/callout.tsx
+++ b/sites/jeromefitzgerald.com/src/components/callout/callout.tsx
@@ -1,10 +1,5 @@
 import { FileTextIcon } from "@jeromefitz/ds/components/icon";
-import type { RootProps as CalloutRootProps } from "@radix-ui/themes/dist/esm/components/callout.js";
-import {
-  Icon as CalloutIcon,
-  Root as CalloutRoot,
-  Text as CalloutText,
-} from "@radix-ui/themes/dist/esm/components/callout.js";
+import { Callout } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 
 import { cx } from "@/utils/cx";
@@ -16,7 +11,7 @@ interface AdditionalProps {
   color?: string;
   icon?: any;
 }
-type CalloutRootPropsImpl = AdditionalProps & CalloutRootProps;
+type CalloutRootPropsImpl = AdditionalProps & Callout.RootProps;
 
 function CalloutImpl({
   children = <>This page is in the process of being updated.</>,
@@ -28,17 +23,17 @@ function CalloutImpl({
   variant = "soft",
 }: CalloutRootPropsImpl) {
   return (
-    <CalloutRoot
+    <Callout.Root
       className={cx("w-full font-mono", className)}
       color={color}
       size={size}
       variant={variant}
     >
-      <CalloutIcon>
+      <Callout.Icon>
         <Icon />
-      </CalloutIcon>
-      <CalloutText className={classNameText}>{children}</CalloutText>
-    </CalloutRoot>
+      </Callout.Icon>
+      <Callout.Text className={classNameText}>{children}</Callout.Text>
+    </Callout.Root>
   );
 }
 

--- a/sites/jeromefitzgerald.com/src/components/container/container.footer.client.tsx
+++ b/sites/jeromefitzgerald.com/src/components/container/container.footer.client.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { InfoCircledIcon } from "@jeromefitz/ds/components/icon";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Flex, Text } from "@radix-ui/themes";
 import { usePathname } from "next/navigation.js";
 
 const IS_COLOPHON_SHOWN = false;

--- a/sites/jeromefitzgerald.com/src/components/container/container.footer.tsx
+++ b/sites/jeromefitzgerald.com/src/components/container/container.footer.tsx
@@ -1,5 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Box, Flex } from "@radix-ui/themes";
 
 import { Currently } from "@/components/currently/currently";
 

--- a/sites/jeromefitzgerald.com/src/components/container/container.gradient.tsx
+++ b/sites/jeromefitzgerald.com/src/components/container/container.gradient.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
+import { Box } from "@radix-ui/themes";
 
 import { cx } from "@/utils/cx";
 

--- a/sites/jeromefitzgerald.com/src/components/container/container.main.tsx
+++ b/sites/jeromefitzgerald.com/src/components/container/container.main.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Flex } from "@radix-ui/themes";
 
 import { cx } from "@/utils/cx";
 

--- a/sites/jeromefitzgerald.com/src/components/container/container.navigation.tsx
+++ b/sites/jeromefitzgerald.com/src/components/container/container.navigation.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
+import { Box } from "@radix-ui/themes";
 
 import { Navigation } from "@/components/navigation/navigation";
 import { cx } from "@/utils/cx";

--- a/sites/jeromefitzgerald.com/src/components/container/container.section.tsx
+++ b/sites/jeromefitzgerald.com/src/components/container/container.section.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
+import { Box } from "@radix-ui/themes";
 
 import { cx } from "@/utils/cx";
 

--- a/sites/jeromefitzgerald.com/src/components/container/container.site.tsx
+++ b/sites/jeromefitzgerald.com/src/components/container/container.site.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Flex } from "@radix-ui/themes";
 
 import { cx } from "@/utils/cx";
 

--- a/sites/jeromefitzgerald.com/src/components/credits/credits.header.tsx
+++ b/sites/jeromefitzgerald.com/src/components/credits/credits.header.tsx
@@ -1,6 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Flex, Heading, Text } from "@radix-ui/themes";
 
 import { cx } from "@/utils/cx";
 

--- a/sites/jeromefitzgerald.com/src/components/credits/credits.item.tsx
+++ b/sites/jeromefitzgerald.com/src/components/credits/credits.item.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Text } from "@radix-ui/themes";
 import { cache } from "react";
 
 // import { getEventData } from '@/app/(notion)/_config/index'

--- a/sites/jeromefitzgerald.com/src/components/credits/credits.items.tsx
+++ b/sites/jeromefitzgerald.com/src/components/credits/credits.items.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Text } from "@radix-ui/themes";
 
 import { LI } from "@/components/list/index";
 

--- a/sites/jeromefitzgerald.com/src/components/credits/credits.loading.tsx
+++ b/sites/jeromefitzgerald.com/src/components/credits/credits.loading.tsx
@@ -1,5 +1,4 @@
-import { Skeleton } from "@radix-ui/themes/dist/esm/components/skeleton.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Skeleton, Text } from "@radix-ui/themes";
 
 import { LI } from "@/components/list/index";
 

--- a/sites/jeromefitzgerald.com/src/components/credits/credits.tsx
+++ b/sites/jeromefitzgerald.com/src/components/credits/credits.tsx
@@ -1,6 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Flex, Text } from "@radix-ui/themes";
 import { map as _map, size as _size } from "lodash-es";
 import pluralize from "pluralize";
 import { Fragment, Suspense } from "react";

--- a/sites/jeromefitzgerald.com/src/components/currently/currently.item.tsx
+++ b/sites/jeromefitzgerald.com/src/components/currently/currently.item.tsx
@@ -1,8 +1,5 @@
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
+import { Code, Em, Skeleton, Text } from "@radix-ui/themes";
 // import { Heading } from '@radix-ui/themes/dist/esm/components/heading.js'
-import { Skeleton } from "@radix-ui/themes/dist/esm/components/skeleton.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
 
 function CodeGhost({ children }: { children: React.ReactNode }) {
   return <Code variant="ghost">{children}</Code>;

--- a/sites/jeromefitzgerald.com/src/components/currently/currently.item.wrapper.tsx
+++ b/sites/jeromefitzgerald.com/src/components/currently/currently.item.wrapper.tsx
@@ -1,7 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Button, Flex, Text } from "@radix-ui/themes";
 import NextLink from "next/link";
 import type { ReactNode } from "react";
 

--- a/sites/jeromefitzgerald.com/src/components/currently/currently.tsx
+++ b/sites/jeromefitzgerald.com/src/components/currently/currently.tsx
@@ -1,7 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Box, Em, Flex, Text } from "@radix-ui/themes";
 import { filter as _filter } from "lodash-es";
 
 import { currently } from "@/data/currently";

--- a/sites/jeromefitzgerald.com/src/components/error-boundary/error-boundary.tsx
+++ b/sites/jeromefitzgerald.com/src/components/error-boundary/error-boundary.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { ExclamationTriangleIcon } from "@jeromefitz/ds/components/icon";
-import { Badge } from "@radix-ui/themes/dist/esm/components/badge.js";
-import { Code } from "@radix-ui/themes/dist/esm/components/code.js";
-import * as DataList from "@radix-ui/themes/dist/esm/components/data-list.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
-import { Separator } from "@radix-ui/themes/dist/esm/components/separator.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Badge, Code, DataList, Flex, Link, Separator, Text } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 import { Component } from "react";
 

--- a/sites/jeromefitzgerald.com/src/components/header/header.full.tsx
+++ b/sites/jeromefitzgerald.com/src/components/header/header.full.tsx
@@ -1,8 +1,5 @@
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Em, Flex, Heading, Text } from "@radix-ui/themes";
 // import { Grid } from '@radix-ui/themes/dist/esm/components/grid.js'
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
 
 import { cx } from "@/utils/cx";
 

--- a/sites/jeromefitzgerald.com/src/components/header/header.sidebar.cta.tsx
+++ b/sites/jeromefitzgerald.com/src/components/header/header.sidebar.cta.tsx
@@ -1,6 +1,5 @@
 import { ExternalLinkIcon } from "@jeromefitz/ds/components/icon";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Button, Text } from "@radix-ui/themes";
 import NextLink from "next/link";
 
 import { cx } from "@/utils/cx";

--- a/sites/jeromefitzgerald.com/src/components/header/header.sidebar.tsx
+++ b/sites/jeromefitzgerald.com/src/components/header/header.sidebar.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 // import { Em } from '@radix-ui/themes/dist/esm/components/em.js'
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Heading } from "@radix-ui/themes/dist/esm/components/heading.js";
+import { Flex, Heading } from "@radix-ui/themes";
 // import { Text } from '@radix-ui/themes/dist/esm/components/text.js'
 
 import { useSticky } from "@/hooks/use-sticky";

--- a/sites/jeromefitzgerald.com/src/components/list/li.tsx
+++ b/sites/jeromefitzgerald.com/src/components/list/li.tsx
@@ -1,5 +1,5 @@
 import { CornerBottomLeftIcon } from "@radix-ui/react-icons";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Flex } from "@radix-ui/themes";
 
 import { cx } from "@/utils/cx";
 

--- a/sites/jeromefitzgerald.com/src/components/list/ol.tsx
+++ b/sites/jeromefitzgerald.com/src/components/list/ol.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Flex } from "@radix-ui/themes";
 
 function OL({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return (

--- a/sites/jeromefitzgerald.com/src/components/list/ul.tsx
+++ b/sites/jeromefitzgerald.com/src/components/list/ul.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Flex } from "@radix-ui/themes";
 
 function UL({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return (

--- a/sites/jeromefitzgerald.com/src/components/navigation/navigation.button.client.tsx
+++ b/sites/jeromefitzgerald.com/src/components/navigation/navigation.button.client.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { MoonIcon, SunIcon } from "@jeromefitz/ds/components/icon";
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import * as SegmentedControl from "@radix-ui/themes/dist/esm/components/segmented-control.js";
-import { Skeleton } from "@radix-ui/themes/dist/esm/components/skeleton.js";
+import { Box, SegmentedControl, Skeleton } from "@radix-ui/themes";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 

--- a/sites/jeromefitzgerald.com/src/components/navigation/navigation.button.tsx
+++ b/sites/jeromefitzgerald.com/src/components/navigation/navigation.button.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Flex } from "@radix-ui/themes";
 
 import { cx } from "@/utils/cx";
 

--- a/sites/jeromefitzgerald.com/src/components/navigation/navigation.primary.tsx
+++ b/sites/jeromefitzgerald.com/src/components/navigation/navigation.primary.tsx
@@ -2,22 +2,19 @@
 
 // import { useHover } from '@mantine/hooks'
 import { DotFilledIcon } from "@radix-ui/react-icons";
-import { AspectRatio } from "@radix-ui/themes/dist/esm/components/aspect-ratio.js";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import { Em } from "@radix-ui/themes/dist/esm/components/em.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Grid } from "@radix-ui/themes/dist/esm/components/grid.js";
-import { Inset } from "@radix-ui/themes/dist/esm/components/inset.js";
-// import { useEffect, useState } from 'react'
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
 import {
-  // Close as PopoverClose,
-  Content as PopoverContent,
-  Root as PopoverRoot,
-  Trigger as PopoverTrigger,
-} from "@radix-ui/themes/dist/esm/components/popover.js";
-import { Strong } from "@radix-ui/themes/dist/esm/components/strong.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+  AspectRatio,
+  Button,
+  Em,
+  Flex,
+  Grid,
+  Inset,
+  Link,
+  Popover,
+  Strong,
+  Text,
+} from "@radix-ui/themes";
+// import { useEffect, useState } from 'react'
 import NextLink from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
@@ -95,7 +92,7 @@ function NavigationPopOver() {
   return (
     // @todo(radix) children
     // @ts-ignore
-    <PopoverRoot
+    <Popover.Root
       modal={true}
       onOpenChange={() => {
         isOverlaySet();
@@ -105,11 +102,11 @@ function NavigationPopOver() {
     >
       <Flex direction="row" gap="3">
         {/* @ts-ignore */}
-        <PopoverTrigger asChild>
+        <Popover.Trigger asChild>
           <NavigationButton />
-        </PopoverTrigger>
+        </Popover.Trigger>
       </Flex>
-      <PopoverContent
+      <Popover.Content
         asChild
         // className="!z-[999]"
         size="1"
@@ -169,8 +166,8 @@ function NavigationPopOver() {
             </Text>
           </Flex>
         </Grid>
-      </PopoverContent>
-    </PopoverRoot>
+      </Popover.Content>
+    </Popover.Root>
   );
 }
 

--- a/sites/jeromefitzgerald.com/src/components/navigation/navigation.secondary.tsx
+++ b/sites/jeromefitzgerald.com/src/components/navigation/navigation.secondary.tsx
@@ -1,20 +1,7 @@
 "use client";
 
 import { HomeIcon } from "@jeromefitz/ds/components/icon";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import {
-  Content as DropdownMenuContent,
-  Item as DropdownMenuItem,
-  Root as DropdownMenuRoot,
-  Separator as DropdownMenuSeparator,
-  Sub as DropdownMenuSub,
-  SubContent as DropdownMenuSubContent,
-  SubTrigger as DropdownMenuSubTrigger,
-  Trigger as DropdownMenuTrigger,
-  TriggerIcon as DropdownMenuTriggerIcon,
-} from "@radix-ui/themes/dist/esm/components/dropdown-menu.js";
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Button, DropdownMenu, Flex, Text } from "@radix-ui/themes";
 import { useRouter } from "next/navigation.js";
 import { Fragment } from "react";
 
@@ -51,8 +38,8 @@ function NavigationSecondary({ order = 0 }) {
       <div className="contents size-full">
         {/* @todo(radix) children */}
         {/* @ts-ignore */}
-        <DropdownMenuRoot modal={false}>
-          <DropdownMenuTrigger>
+        <DropdownMenu.Root modal={false}>
+          <DropdownMenu.Trigger>
             <Flex
               asChild
               className={cx(
@@ -79,16 +66,16 @@ function NavigationSecondary({ order = 0 }) {
                   {!isDisabled && <IconSecondary className="ml-1" />}
                   {!isDisabled && <Text>{zzz_menuSecondaryActive.title}</Text>}
                 </div>
-                <DropdownMenuTriggerIcon className="size-5" />
+                <DropdownMenu.TriggerIcon className="size-5" />
               </Button>
             </Flex>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="z-50 min-w-41.25" sideOffset={6} size="2">
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content className="z-50 min-w-41.25" sideOffset={6} size="2">
             {zzz_menuSecondary.map((item: any, idx: number) => {
               if (!item.isActive && !item.isActiveMobile) return null;
               const key = `secondary-${idx}-${item.id}`;
               if (item.title === "SEP") {
-                return <DropdownMenuSeparator key={key} />;
+                return <DropdownMenu.Separator key={key} />;
               }
 
               const Icon = item.icon;
@@ -103,7 +90,7 @@ function NavigationSecondary({ order = 0 }) {
                       md: "flex",
                     }}
                   >
-                    <DropdownMenuItem
+                    <DropdownMenu.Item
                       className={cx(
                         !!mt && "hidden md:flex",
                         !item.isActive && item.isActiveMobile && "hidden!",
@@ -117,18 +104,18 @@ function NavigationSecondary({ order = 0 }) {
                     >
                       <Icon className="hidden size-5 md:inline-flex" />
                       <Text size={{ initial: "2", md: "3" }}>{item.title}</Text>
-                    </DropdownMenuItem>
+                    </DropdownMenu.Item>
                   </Flex>
                   {!!mt && (
                     <Flex asChild>
-                      <DropdownMenuSub>
+                      <DropdownMenu.Sub>
                         <Flex asChild display={{ initial: "flex", md: "none" }}>
-                          <DropdownMenuSubTrigger className="hidden">
+                          <DropdownMenu.SubTrigger className="hidden">
                             <Text size={{ initial: "2", md: "3" }}>{item.title}</Text>
-                          </DropdownMenuSubTrigger>
+                          </DropdownMenu.SubTrigger>
                         </Flex>
                         {/* @ts-ignore */}
-                        <DropdownMenuSubContent size={{ initial: "2", md: "3" }}>
+                        <DropdownMenu.SubContent size={{ initial: "2", md: "3" }}>
                           {/* @ts-ignore */}
                           {mt.map((itemSub) => {
                             if (!itemSub.isActive && !itemSub.isActiveMobile) return null;
@@ -140,7 +127,7 @@ function NavigationSecondary({ order = 0 }) {
                             return (
                               <Fragment key={key}>
                                 <Flex asChild>
-                                  <DropdownMenuItem
+                                  <DropdownMenu.Item
                                     className={cx(
                                       itemSub.isActive &&
                                         !itemSub.isActiveMobile &&
@@ -160,20 +147,20 @@ function NavigationSecondary({ order = 0 }) {
                                     >
                                       {itemSub.title}
                                     </Text>
-                                  </DropdownMenuItem>
+                                  </DropdownMenu.Item>
                                 </Flex>
                               </Fragment>
                             );
                           })}
-                        </DropdownMenuSubContent>
-                      </DropdownMenuSub>
+                        </DropdownMenu.SubContent>
+                      </DropdownMenu.Sub>
                     </Flex>
                   )}
                 </Fragment>
               );
             })}
-          </DropdownMenuContent>
-        </DropdownMenuRoot>
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
       </div>
     </div>
   );

--- a/sites/jeromefitzgerald.com/src/components/navigation/navigation.tertiary.tsx
+++ b/sites/jeromefitzgerald.com/src/components/navigation/navigation.tertiary.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import { DotFilledIcon } from "@radix-ui/react-icons";
-import { Button } from "@radix-ui/themes/dist/esm/components/button.js";
-import {
-  Content as DropdownMenuContent,
-  Item as DropdownMenuItem,
-  Root as DropdownMenuRoot,
-  Separator as DropdownMenuSeparator,
-  Trigger as DropdownMenuTrigger,
-  TriggerIcon as DropdownMenuTriggerIcon,
-} from "@radix-ui/themes/dist/esm/components/dropdown-menu.js";
-import { Text } from "@radix-ui/themes/dist/esm/components/text.js";
+import { Button, DropdownMenu, Text } from "@radix-ui/themes";
 import { useRouter } from "next/navigation.js";
 import { Fragment } from "react";
 
@@ -51,8 +42,8 @@ function NavigationTertiary({ className, order = 0 }: { className: string; order
         <div className={cx()}>
           {/* @todo(radix) children */}
           {/* @ts-ignore */}
-          <DropdownMenuRoot modal={false}>
-            <DropdownMenuTrigger className={cx(isDisabled && "hover:cursor-not-allowed")}>
+          <DropdownMenu.Root modal={false}>
+            <DropdownMenu.Trigger className={cx(isDisabled && "hover:cursor-not-allowed")}>
               <Button
                 aria-label={isDisabled ? "Disabled Tertiary Menu" : "Tertiary Menu"}
                 className={cx(
@@ -80,11 +71,11 @@ function NavigationTertiary({ className, order = 0 }: { className: string; order
                   {!isDisabled && <DropdownMenuTriggerIconType className="ml-1 size-5" />}
                   {zzz_menuTertiaryActive?.title}
                 </div>
-                {!isDisabled && <DropdownMenuTriggerIcon />}
+                {!isDisabled && <DropdownMenu.TriggerIcon />}
               </Button>
-            </DropdownMenuTrigger>
+            </DropdownMenu.Trigger>
             {!isDisabled && (
-              <DropdownMenuContent sideOffset={6} size="2" style={{ minWidth: "310px" }}>
+              <DropdownMenu.Content sideOffset={6} size="2" style={{ minWidth: "310px" }}>
                 {/* @ts-ignore */}
                 {mt?.map((item, idx) => {
                   if (!item.isActive && !item.isActiveMobile) return null;
@@ -92,7 +83,7 @@ function NavigationTertiary({ className, order = 0 }: { className: string; order
                   const key = `tertiary-${idx}-${item.id}`;
 
                   if (item.title === "SEP") {
-                    return <DropdownMenuSeparator key={key} />;
+                    return <DropdownMenu.Separator key={key} />;
                   }
 
                   const DropdownMenuItemIcon = item.icon;
@@ -100,7 +91,7 @@ function NavigationTertiary({ className, order = 0 }: { className: string; order
                   return (
                     <Fragment key={key}>
                       {/* @ts-ignore */}
-                      <DropdownMenuItem
+                      <DropdownMenu.Item
                         className={cx(
                           item.isActive && !item.isActiveMobile && "hidden",
                           !item.isActive && item.isActiveMobile && "md:hidden",
@@ -121,13 +112,13 @@ function NavigationTertiary({ className, order = 0 }: { className: string; order
                         <Text className="line-clamp-1" size="3">
                           {item.title}
                         </Text>
-                      </DropdownMenuItem>
+                      </DropdownMenu.Item>
                     </Fragment>
                   );
                 })}
-              </DropdownMenuContent>
+              </DropdownMenu.Content>
             )}
-          </DropdownMenuRoot>
+          </DropdownMenu.Root>
         </div>
       </div>
     </div>

--- a/sites/jeromefitzgerald.com/src/components/navigation/navigation.tsx
+++ b/sites/jeromefitzgerald.com/src/components/navigation/navigation.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@radix-ui/themes/dist/esm/components/flex.js";
+import { Flex } from "@radix-ui/themes";
 
 import { cx } from "@/utils/cx";
 

--- a/sites/jeromefitzgerald.com/src/components/skip-nav/skip-nav.tsx
+++ b/sites/jeromefitzgerald.com/src/components/skip-nav/skip-nav.tsx
@@ -1,5 +1,4 @@
-import { Box } from "@radix-ui/themes/dist/esm/components/box.js";
-import { Link } from "@radix-ui/themes/dist/esm/components/link.js";
+import { Box, Link } from "@radix-ui/themes";
 import type { Ref } from "react";
 
 import { cx } from "@/utils/cx";


### PR DESCRIPTION
Since `3.3.0` no longer need to do the `dist/...` dance.

- `"sideEffects": ["*.css"]` — marks all JS files as side-effect-free, so bundlers can safely drop anything you don't import
- `import` condition in the exports map resolves to real ESM files (`export`/`import` statements), not CJS dressed up as ESM
- Proper export map — `"."` → `dist/esm/index.js` for the `import` condition, so bundlers hit the ESM barrel directly rather than needing the hand-rolled dist path workaround


## Future

Need to address all the commented out code but focused solely on shipped at the moment.