### PR TITLE
🔧 (dx) add validate and validate:full scripts [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "semantic-release": "pnpm run semantic-release:mono",
     "semantic-release:dry": "pnpm semantic-release:mono --dry-run",
     "semantic-release:mono": "pnpm --filter jeromefitzgerald.com -r --workspace-concurrency=1 exec -- pnpm dlx semantic-release",
-    "turbo": "TURBO_TELEMETRY_DISABLED=1 turbo"
+    "turbo": "TURBO_TELEMETRY_DISABLED=1 turbo",
+    "validate": "pnpm turbo //#quality lint:ts && pnpm run lint:packages",
+    "validate:full": "pnpm turbo //#quality lint:ts test:unit && pnpm run lint:packages"
   },
   "devDependencies": {
     "@arethetypeswrong/core": "0.18.3",


### PR DESCRIPTION
## Summary

- Adds `pnpm run validate` — fast pre-push check: format + lint + types + package sync
- Adds `pnpm run validate:full` — same + `test:unit` for pre-PR confidence
- Relies on existing `pre-commit` hook for per-commit checks; `validate` fills the gap with `lint:ts` which the hook does not cover

## Test plan

- [x] `pnpm run validate` passes clean
- [x] `pnpm run validate:full` passes clean