### PR TITLE
🐛 (github) deploy action; vercel production url parse [b]

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -61,11 +61,19 @@ runs:
         VERCEL_PROJECT_ID: ${{ inputs.VERCEL_PROJECT_ID }}
       run: |
         if [ "${{ inputs.PRODUCTION }}" = "true" ]; then
-          timeout 300 vercel deploy --prod --token=${{ inputs.VERCEL_TOKEN }} 2>&1 | tee /tmp/vercel-deploy.log
-          production_url=$(grep 'Production:' /tmp/vercel-deploy.log | grep -oE 'https://[^[:space:]]+' | head -1)
+          timeout 300 vercel deploy --prod --token=${{ inputs.VERCEL_TOKEN }} 2>&1 | tee /tmp/vercel-deploy.log || true
+          if ! grep -qE 'Deployment completed|Ready in' /tmp/vercel-deploy.log; then
+            echo "Vercel deployment failed — no success indicator found in logs"
+            exit 1
+          fi
+          production_url=$(grep -E 'Production' /tmp/vercel-deploy.log | grep -oE 'https://[^[:space:]]+' | head -1)
           echo "production_url=$production_url" >> $GITHUB_OUTPUT
         else
-          timeout 300 vercel deploy --token=${{ inputs.VERCEL_TOKEN }} 2>&1 | tee /tmp/vercel-deploy.log
+          timeout 300 vercel deploy --token=${{ inputs.VERCEL_TOKEN }} 2>&1 | tee /tmp/vercel-deploy.log || true
+          if ! grep -qE 'Deployment completed|Ready in' /tmp/vercel-deploy.log; then
+            echo "Vercel deployment failed — no success indicator found in logs"
+            exit 1
+          fi
           preview_url=$(grep -oE 'https://[a-zA-Z0-9-]+\.vercel\.app' /tmp/vercel-deploy.log | head -1)
           inspect_url=$(grep -oE 'https://vercel\.com/[^[:space:]]+' /tmp/vercel-deploy.log | head -1)
           echo "preview_url=$preview_url" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- `vercel deploy --prod` exits with code 1 even on successful deployments, failing the GitHub Actions step
- `production_url` grep used `'Production:'` (with colon) but Vercel's output format is `  Production      https://...` (spaces, no colon), so the URL was never captured and `wf-gh-deployment` was always skipped
- Applied same resilience to the preview path for consistency

## Test plan

- [x] CI runs full build + deploy on merge (no `[skip ci]`)
- ~~`🔺️ Deploy (Production)` step passes and `wf-gh-deployment` creates a deployment status~~ Can only test ... when it is merged 
- [x] Preview deploy path unaffected
