### PR TITLE
🔧 (config) syncpack allow ^ range for override-managed deps [b]

### DIFF
--- a/.syncpackrc.ts
+++ b/.syncpackrc.ts
@@ -17,6 +17,13 @@ export default {
       packages: ["**"],
     },
     {
+      dependencies: ["postcss", "typescript"],
+      dependencyTypes: ["dev", "prod"],
+      label: "range:  override-managed",
+      packages: ["**"],
+      range: "^",
+    },
+    {
       dependencies: ["**"],
       dependencyTypes: ["dev", "local", "overrides", "prod"],
       label: "types:  !peer",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "syncpack": "15.3.2",
     "tsdown": "0.22.3",
     "turbo": "2.10.0",
-    "typescript": "6.0.3"
+    "typescript": "^6.0.3"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -13,7 +13,7 @@
     "autoprefixer": "10.5.2",
     "cssnano": "8.0.2",
     "lightningcss": "1.32.0",
-    "postcss": "8.5.15",
+    "postcss": "^8.5.15",
     "radix-themes-tw": "1.1.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/sites/jeromefitzgerald.com/package.json
+++ b/sites/jeromefitzgerald.com/package.json
@@ -144,7 +144,7 @@
     "sharp": "0.35.2",
     "tailwindcss-radix": "4.0.2",
     "tw-animate-css": "1.4.0",
-    "typescript": "6.0.3",
+    "typescript": "^6.0.3",
     "vite": "8.1.0",
     "vitest": "4.1.9",
     "zod": "4.4.3"


### PR DESCRIPTION
## Summary

- Adds `semverGroups` exception in `.syncpackrc.ts` for `postcss` and `typescript`, allowing `^` ranges instead of enforcing exact pins
- These two packages are managed via `pnpm-workspace.yaml` overrides, so the range propagates naturally from there
- Updates `typescript` entries in `package.json` and `sites/jeromefitzgerald.com/package.json` from `6.0.3` → `^6.0.3`
- Updates `postcss` in `packages/tailwind-config/package.json` from `8.5.15` → `^8.5.15`

## Test plan

- [x] `pnpm lint:packages` passes with no issues