### PR TITLE
🔧 (mend) restore renovate automation [skip ci]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
   "commitMessagePrefix": "⬆️  (deps)",
   "commitMessageSuffix": "",
   "commitMessageTopic": " {{depName}}@{{#if isPinDigest}}{{{newDigest}}}{{else}}{{#if isMajor}}{{{newVersion}}} 🧨 {{else}}{{#if isSingleVersion}}{{{newVersion}}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}@{{{newDigest}}}{{/if}}{{/if}}{{/if}}{{/if}}",
-  "dependencyDashboard": false,
+  "dependencyDashboard": true,
   "extends": [":semanticCommitsDisabled"],
   "labels": ["📦️ Dependencies"],
   "node": {

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,14 +8,6 @@ allowBuilds:
   turbo: true
 autoInstallPeers: false
 lockfile: true
-minimumReleaseAgeExclude:
-  - "@turbo/darwin-64@2.10.0"
-  - "@turbo/darwin-arm64@2.10.0"
-  - "@turbo/linux-64@2.10.0"
-  - "@turbo/linux-arm64@2.10.0"
-  - "@turbo/windows-64@2.10.0"
-  - "@turbo/windows-arm64@2.10.0"
-  - turbo@2.10.0
 overrides:
   "@babel/core@^7.0.0": ^7.29.6
   "@babel/helpers@^7.0.0": ^7.29.2
@@ -68,11 +60,4 @@ publicHoistPattern:
 registry: https://registry.npmjs.org/
 saveExact: true
 strictPeerDependencies: false
-supportedArchitectures:
-  os:
-    - darwin
-    - current
-  cpu:
-    - x64
-    - arm64
 tagVersionPrefix: ""


### PR DESCRIPTION
- **Remove:** `supportedArchitectures` from `pnpm-workspace.yaml` — was causing Renovate's Linux runner to produce mismatched lockfile diffs
- **Remove:** `minimumReleaseAgeExclude` from `pnpm-workspace.yaml` — stale turbo version pins, no longer needed
- **Add:** `.npmrc` with registry — ensures Renovate can find pnpm registry config without relying solely on `pnpm-workspace.yaml` parsing
- **Enable:** `dependencyDashboard` in `renovate.json` — surfaces any remaining errors as a GitHub issue instead of failing silently