### PR TITLE
🔧 (pnpm) rm outdated overrides [cve] [skip ci]

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,29 +207,20 @@ overrides:
   '@babel/core@^7.0.0': ^7.29.6
   '@babel/helpers@^7.0.0': ^7.29.2
   '@babel/runtime@^7.0.0': ^7.29.2
-  '@octokit/plugin-paginate-rest@^14.0.0': ^14.0.0
   '@semantic-release/npm@^13.0.0': ^13.1.5
-  brace-expansion@^1.0.0: 1.1.13
   cross-spawn@^7.0.0: ^7.0.6
-  elliptic@^6.0.0: ^6.6.1
   esbuild@^0.18.0: ^0.28.0
   esbuild@^0.25.0: ^0.28.0
   flatted@^3.0.0: ^3.4.2
   handlebars@^4.0.0: ^4.7.9
-  h3@^1.0.0: ^1.15.9
   js-yaml@^4.0.0: ^4.2.0
-  launch-editor@^2.0.0: ^2.14.1
   micromatch@^4.0.0: ^4.0.8
   nanoid@^3.0.0: ^3.3.8
-  pbkdf2@^3.0.0: ^3.1.5
   picomatch@^2.0.0: ^2.3.2
   postcss@^8.0.0: ^8.5.15
-  preact@^10.0.0: ^10.26.10
   semver@^5.0.0: ^5.7.2
   semver@^6.0.0: ^6.3.1
   semver@^7.0.0: ^7.7.4
-  sha.js@^2.0.0: ^2.4.12
-  shell-quote@^1.0.0: ^1.8.4
   typescript: ^6.0.3
   undici@^6.0.0: ^6.27.0
   undici@^7.0.0: ^7.28.0
@@ -3772,10 +3763,6 @@ packages:
     peerDependencies:
       typescript: ^6.0.3
 
-  '@typescript-eslint/scope-manager@8.61.1':
-    resolution: {integrity: sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/scope-manager@8.62.0':
     resolution: {integrity: sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3785,10 +3772,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: ^6.0.3
-
-  '@typescript-eslint/types@8.61.1':
-    resolution: {integrity: sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/types@8.62.0':
     resolution: {integrity: sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==}
@@ -3806,10 +3789,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ^6.0.3
-
-  '@typescript-eslint/visitor-keys@8.61.1':
-    resolution: {integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.62.0':
     resolution: {integrity: sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==}
@@ -4077,11 +4056,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
@@ -5435,10 +5409,6 @@ packages:
 
   node-modules-tools@1.4.2:
     resolution: {integrity: sha512-qJXhrQU0Puj6yA70Hi+shAfHTg6gK4/bdjGletk3L7tCch4PM/TEvGkFo2ZpixjAf54Kdu36ZsW4jU8/S24eZw==}
-
-  node-releases@2.0.48:
-    resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
-    engines: {node: '>=18'}
 
   node-releases@2.0.49:
     resolution: {integrity: sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==}
@@ -9207,11 +9177,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.61.1':
-    dependencies:
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/visitor-keys': 8.61.1
-
   '@typescript-eslint/scope-manager@8.62.0':
     dependencies:
       '@typescript-eslint/types': 8.62.0
@@ -9220,8 +9185,6 @@ snapshots:
   '@typescript-eslint/tsconfig-utils@8.62.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
-
-  '@typescript-eslint/types@8.61.1': {}
 
   '@typescript-eslint/types@8.62.0': {}
 
@@ -9250,11 +9213,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/visitor-keys@8.61.1':
-    dependencies:
-      '@typescript-eslint/types': 8.61.1
-      eslint-visitor-keys: 5.0.1
 
   '@typescript-eslint/visitor-keys@8.62.0':
     dependencies:
@@ -9491,14 +9449,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.38
-      caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.378
-      node-releases: 2.0.48
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
   browserslist@4.28.4:
     dependencies:
       baseline-browser-mapping: 2.10.38
@@ -9527,7 +9477,7 @@ snapshots:
 
   caniuse-api@4.0.0:
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       caniuse-lite: 1.0.30001799
 
   caniuse-lite@1.0.30001799: {}
@@ -9735,7 +9685,7 @@ snapshots:
 
   cssnano-preset-default@8.0.2(postcss@8.5.15):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       cssnano-utils: 6.0.1(postcss@8.5.15)
       postcss: 8.5.15
       postcss-calc: 10.1.1(postcss@8.5.15)
@@ -9967,7 +9917,7 @@ snapshots:
 
   eslint-plugin-testing-library@7.16.2(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/scope-manager': 8.62.0
       '@typescript-eslint/utils': 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.5.0(jiti@2.7.0)
     transitivePeerDependencies:
@@ -10787,8 +10737,6 @@ snapshots:
       semver: 7.8.5
       tinyexec: 1.2.4
 
-  node-releases@2.0.48: {}
-
   node-releases@2.0.49: {}
 
   normalize-package-data@6.0.2:
@@ -11065,14 +11013,14 @@ snapshots:
   postcss-colormin@8.0.1(postcss@8.5.15):
     dependencies:
       '@colordx/core': 5.4.3
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       caniuse-api: 4.0.0
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-convert-values@8.0.1(postcss@8.5.15):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
@@ -11101,7 +11049,7 @@ snapshots:
 
   postcss-merge-rules@8.0.1(postcss@8.5.15):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       caniuse-api: 4.0.0
       cssnano-utils: 6.0.1(postcss@8.5.15)
       postcss: 8.5.15
@@ -11121,14 +11069,14 @@ snapshots:
 
   postcss-minify-params@8.0.1(postcss@8.5.15):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       cssnano-utils: 6.0.1(postcss@8.5.15)
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-minify-selectors@8.0.2(postcss@8.5.15):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       caniuse-api: 4.0.0
       cssesc: 3.0.0
       postcss: 8.5.15
@@ -11165,7 +11113,7 @@ snapshots:
 
   postcss-normalize-unicode@8.0.1(postcss@8.5.15):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
@@ -11187,7 +11135,7 @@ snapshots:
 
   postcss-reduce-initial@8.0.1(postcss@8.5.15):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       caniuse-api: 4.0.0
       postcss: 8.5.15
 
@@ -11770,7 +11718,7 @@ snapshots:
 
   stylehacks@8.0.1(postcss@8.5.15):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       postcss: 8.5.15
       postcss-selector-parser: 7.1.4
 
@@ -12045,12 +11993,6 @@ snapshots:
     optionalDependencies:
       '@upstash/redis': 1.38.0
       ioredis: 5.11.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.4):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,29 +12,20 @@ overrides:
   "@babel/core@^7.0.0": ^7.29.6
   "@babel/helpers@^7.0.0": ^7.29.2
   "@babel/runtime@^7.0.0": ^7.29.2
-  "@octokit/plugin-paginate-rest@^14.0.0": ^14.0.0
   "@semantic-release/npm@^13.0.0": ^13.1.5
-  brace-expansion@^1.0.0: 1.1.13
   cross-spawn@^7.0.0: ^7.0.6
-  elliptic@^6.0.0: ^6.6.1
   esbuild@^0.18.0: ^0.28.0
   esbuild@^0.25.0: ^0.28.0
   flatted@^3.0.0: ^3.4.2
   handlebars@^4.0.0: ^4.7.9
-  h3@^1.0.0: ^1.15.9
   js-yaml@^4.0.0: ^4.2.0
-  launch-editor@^2.0.0: ^2.14.1
   micromatch@^4.0.0: ^4.0.8
   nanoid@^3.0.0: ^3.3.8
-  pbkdf2@^3.0.0: ^3.1.5
   picomatch@^2.0.0: ^2.3.2
   postcss@^8.0.0: ^8.5.15
-  preact@^10.0.0: ^10.26.10
   semver@^5.0.0: ^5.7.2
   semver@^6.0.0: ^6.3.1
   semver@^7.0.0: ^7.7.4
-  sha.js@^2.0.0: ^2.4.12
-  shell-quote@^1.0.0: ^1.8.4
   typescript: ^6.0.3
   undici@^6.0.0: ^6.27.0
   undici@^7.0.0: ^7.28.0


### PR DESCRIPTION
- **Remove:** `elliptic`, `pbkdf2`, `preact`, `sha.js` — no longer in the dependency tree
- **Remove:** `brace-expansion@^1.0.0` — only v5 exists in tree, no v1.x requesters remain
- **Remove:** `@octokit/plugin-paginate-rest@^14.0.0: ^14.0.0` — no-op, override equals what installs naturally
- **Remove:** `h3`, `launch-editor`, `shell-quote` — resolved version already meets floor, all from `node-modules-inspector`
- **Run:** `pnpm dedupe` — dropped 6 packages after override removal