### PR TITLE
🔧 (renovate) overrides w/ no majors [skip ci]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,11 @@
   },
   "packageRules": [
     {
+      "enabled": false,
+      "matchDepTypes": ["overrides"],
+      "matchUpdateTypes": ["major"]
+    },
+    {
       "commitMessageExtra": "{{depName}}@{{#if isPinDigest}}{{{newDigest}}}{{else}}{{#if isMajor}}{{{newVersion}}} 🧨 {{else}}{{#if isSingleVersion}}{{{newVersion}}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigest}}}{{/if}}{{/if}}{{/if}}{{/if}}",
       "commitMessagePrefix": "👷  (actions)",
       "commitMessageTopic": " {{depName}}",


### PR DESCRIPTION
- **Add:** `packageRule` targeting `matchDepTypes: ["overrides"]` + `matchUpdateTypes: ["major"]` — Renovate will no longer open major version PRs for CVE override entries; minor/patch still flow through normally