### PR TITLE
🔧 (renovate) minimumReleaseAge 1 day for npm [skip ci]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,10 @@
       "matchUpdateTypes": ["major"]
     },
     {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "1 day"
+    },
+    {
       "commitMessageExtra": "{{depName}}@{{#if isPinDigest}}{{{newDigest}}}{{else}}{{#if isMajor}}{{{newVersion}}} 🧨 {{else}}{{#if isSingleVersion}}{{{newVersion}}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigest}}}{{/if}}{{/if}}{{/if}}{{/if}}",
       "commitMessagePrefix": "👷  (actions)",
       "commitMessageTopic": " {{depName}}",


### PR DESCRIPTION
- **Add:** `minimumReleaseAge: "1 day"` scoped to `matchDatasources: ["npm"]` — mirrors pnpm v11's built-in default, preventing Renovate from opening PRs for packages published within the last 24 hours that would fail pnpm's supply-chain policy check