### PR TITLE
🔧 (renovate) overrides w/ no majors fix [skip ci]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,7 @@
     },
     {
       "enabled": false,
-      "matchDepTypes": ["overrides"],
+      "matchFileNames": ["pnpm-workspace.yaml"],
       "matchUpdateTypes": ["major"]
     },
     {


### PR DESCRIPTION
## Summary
- Replace invalid `matchDepTypes: ["overrides"]` with `matchFileNames: ["pnpm-workspace.yaml"]` — Renovate classifies pnpm-workspace.yaml overrides by source file, not depType
- Fixes the `⚠️ WARN: Found renovate config warnings` showing in dependency dashboard (#4191)
- Blocks major version PRs for overrides only; all other deps (regular package.json deps) continue to get major PRs normally