### PR TITLE
🔧 (renovate) fix dep warn; actor-based skip check [skip ci]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,10 +3,9 @@
   "automerge": false,
   "baseBranchPatterns": ["main"],
   "branchPrefix": "deps/",
-  "commitMessage": "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}",
-  "commitMessageAction": "",
+  "commitMessageAction": "(deps)",
   "commitMessageExtra": "",
-  "commitMessagePrefix": "⬆️  (deps)",
+  "commitMessagePrefix": "⬆️",
   "commitMessageSuffix": "",
   "commitMessageTopic": " {{depName}}@{{#if isPinDigest}}{{{newDigest}}}{{else}}{{#if isMajor}}{{{newVersion}}} 🧨 {{else}}{{#if isSingleVersion}}{{{newVersion}}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}@{{{newDigest}}}{{/if}}{{/if}}{{/if}}{{/if}}",
   "dependencyDashboard": true,
@@ -27,42 +26,47 @@
       "minimumReleaseAge": "1 day"
     },
     {
-      "commitMessageExtra": "{{depName}}@{{#if isPinDigest}}{{{newDigest}}}{{else}}{{#if isMajor}}{{{newVersion}}} 🧨 {{else}}{{#if isSingleVersion}}{{{newVersion}}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigest}}}{{/if}}{{/if}}{{/if}}{{/if}}",
-      "commitMessagePrefix": "👷  (actions)",
-      "commitMessageTopic": " {{depName}}",
+      "commitMessageAction": "(actions)",
+      "commitMessagePrefix": "👷",
       "groupName": "github actions :octocat: ",
       "groupSlug": "github-actions",
       "matchPackageNames": ["/^actions/"]
     },
     {
-      "commitMessagePrefix": "⬆️  (deps)",
+      "commitMessageAction": "(deps)",
+      "commitMessagePrefix": "⬆️",
       "commitMessageSuffix": "[b]",
       "groupName": "radix-ui 🌐 ",
       "groupSlug": "radix-ui",
       "matchPackageNames": ["!@radix-ui/themes", "/^@radix-ui//"]
     },
     {
-      "commitMessagePrefix": "⬆️  (deps)",
+      "commitMessageAction": "(deps)",
+      "commitMessagePrefix": "⬆️",
       "groupName": "react ⚛️ ",
       "groupSlug": "react",
       "matchPackageNames": ["@types/react", "@types/react-dom", "react", "react-dom"]
     },
     {
-      "commitMessagePrefix": "📦  (deps-peer)",
+      "commitMessageAction": "(deps-peer)",
+      "commitMessagePrefix": "📦",
       "matchDepTypes": ["peerDependencies"]
     },
     {
-      "commitMessagePrefix": "📦  (deps-dev)",
+      "commitMessageAction": "(deps-dev)",
+      "commitMessagePrefix": "📦",
       "matchPackageNames": ["@types/*", "!@types/node", "!@types/react", "!@types/react-dom"]
     },
     {
       "allowedVersions": "<25",
-      "commitMessagePrefix": "📦  (deps-dev)",
+      "commitMessageAction": "(deps-dev)",
+      "commitMessagePrefix": "📦",
       "matchDepTypes": ["devDependencies", "dependencies"],
       "matchPackageNames": ["@types/node"]
     },
     {
-      "commitMessagePrefix": "📦  (deps-dev)",
+      "commitMessageAction": "(deps-dev)",
+      "commitMessagePrefix": "📦",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": [
         "@jeromefitz/*",
@@ -79,18 +83,21 @@
       ]
     },
     {
-      "commitMessagePrefix": "⬆️  (deps)",
+      "commitMessageAction": "(deps)",
+      "commitMessagePrefix": "⬆️",
       "matchDepTypes": ["dependencies"]
     },
     {
-      "commitMessagePrefix": "📦  (deps-dev)",
+      "commitMessageAction": "(deps-dev)",
+      "commitMessagePrefix": "📦",
       "groupName": "tailwind 🌬️ ",
       "groupSlug": "tailwind",
       "matchPackageNames": ["/^@tailwind//", "/tailwind*/"]
     },
     {
       "assignees": ["JeromeFitz"],
-      "commitMessagePrefix": "⬆️  (deps)",
+      "commitMessageAction": "(deps)",
+      "commitMessagePrefix": "⬆️",
       "commitMessageSuffix": "[b]",
       "groupName": "radix-ui/themes 🎨 ",
       "groupSlug": "radix-ui/themes",
@@ -98,7 +105,8 @@
       "reviewers": ["JeromeFitz"]
     },
     {
-      "commitMessagePrefix": "📦  (deps-dev)",
+      "commitMessageAction": "(deps-dev)",
+      "commitMessagePrefix": "📦",
       "groupName": "vitest",
       "groupSlug": "vitest",
       "matchPackageNames": ["vitest", "/^@vitest//"]
@@ -132,7 +140,6 @@
   "prFooter": "<!-- COMMIT_BODY_TEXT_END -->",
   "prHeader": "<!-- COMMIT_BODY_TEXT_BEGIN -->",
   "prHourlyLimit": 2,
-  "prTitle": "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip ci]",
   "rebaseWhen": "conflicted",
   "semanticCommits": "disabled"
 }

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,7 +67,7 @@ env:
 jobs:
   pull:
     name: "👷️  CI"
-    if: (contains(github.event.head_commit.message, '[b]') || github.ref == 'refs/heads/main') && !contains(github.event.head_commit.message, '[skip ci]')
+    if: (contains(github.event.head_commit.message, '[b]') || (github.ref == 'refs/heads/main' && github.actor != 'renovate[bot]')) && !contains(github.event.head_commit.message, '[skip ci]')
     timeout-minutes: 20
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary

- Remove deprecated `commitMessage` and `prTitle` top-level fields
- Restructure commit message components: `commitMessagePrefix` → gitmoji, `commitMessageAction` → scope
- Simplify GitHub Actions package rule (drop redundant `commitMessageExtra` and `commitMessageTopic` overrides)
- Add actor-based CI skip to `push.yml` — Renovate merges no longer need `[skip ci]` in the PR title
- `commitMessageSuffix: "[b]"` preserved on radix-ui and radix-ui/themes rules (intentional full build trigger)

## Push job condition

```
(contains('[b]') || (on main && not renovate[bot])) && !contains('[skip ci]')
```

| Who | Branch | `[b]`? | `[skip ci]`? | Runs? |
|---|---|---|---|---|
| Human | main | no | no | ✓ |
| Human | main | no | yes | ✗ |
| Human | main | yes | no | ✓ |
| Human | feature | yes | no | ✓ |
| Human | feature | no | no | ✗ |
| renovate[bot] | main | no | no | ✗ |
| renovate[bot] | main | yes | no | ✓ |

## Test plan

- [x] Renovate Dependency Dashboard issue appears (confirms config is valid)
- [x] Next Renovate PR merging to main skips the push job
- [x] Manually editing a Renovate PR title to include `[b]` causes the push job to run on merge